### PR TITLE
Resizeable sidebar

### DIFF
--- a/app/bun.lock
+++ b/app/bun.lock
@@ -1288,6 +1288,7 @@
 
     "@types/parse-gitignore": ["@types/parse-gitignore@1.0.2", "", { "dependencies": { "@types/node": "*" } }, "sha512-AQwj+lNTWI7y1kkMe8qLByiToXoXs/du70qGFIHJZaJUVrF5jB8QzvWmLyR1VWYqRagpY8ABrqAjs7uHsJnVBQ=="],
 
+
     "@types/pg": ["@types/pg@8.20.0", "", { "dependencies": { "@types/node": "*", "pg-protocol": "*", "pg-types": "^2.2.0" } }, "sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow=="],
 
     "@types/picomatch": ["@types/picomatch@4.0.3", "", {}, "sha512-iG0T6+nYJ9FAPmx9SsUlnwcq1ZVRuCXcVEvWnntoPlrOpwtSTKNDC9uVAxTsC3PUvJ+99n4RpAcNgBbHX3JSnQ=="],

--- a/app/src/components/regionen/pageRegionSlug/SidebarInspector/ResizeHandle.tsx
+++ b/app/src/components/regionen/pageRegionSlug/SidebarInspector/ResizeHandle.tsx
@@ -1,0 +1,26 @@
+import { forwardRef } from 'react'
+
+type Props = {
+  onResizeStart: (e: React.MouseEvent) => void
+  inspectorWidth: number
+}
+
+export const ResizeHandle = forwardRef<HTMLDivElement, Props>(
+  ({ onResizeStart, inspectorWidth }, ref) => {
+    return (
+      <div
+        ref={ref}
+        className="fixed top-0 bottom-0 z-30 w-1 cursor-col-resize hover:bg-purple-500 transition-colors duration-150"
+        style={{ right: `${inspectorWidth - 1}px` }}
+        onMouseDown={onResizeStart}
+        role="separator"
+        aria-orientation="vertical"
+        aria-label="Größe der Sidebar ändern"
+      >
+        <div className="absolute left-0 top-0 bottom-0 w-3 -translate-x-1" />
+      </div>
+    )
+  },
+)
+
+ResizeHandle.displayName = 'ResizeHandle'

--- a/app/src/components/regionen/pageRegionSlug/SidebarInspector/ResizeHandle.tsx
+++ b/app/src/components/regionen/pageRegionSlug/SidebarInspector/ResizeHandle.tsx
@@ -10,14 +10,14 @@ export const ResizeHandle = forwardRef<HTMLDivElement, Props>(
     return (
       <div
         ref={ref}
-        className="fixed top-0 bottom-0 z-30 w-1 cursor-col-resize hover:bg-purple-500 transition-colors duration-150"
+        className="fixed top-0 bottom-0 z-30 w-1 cursor-col-resize transition-colors duration-150 hover:bg-purple-500"
         style={{ right: `${inspectorWidth - 1}px` }}
         onMouseDown={onResizeStart}
         role="separator"
         aria-orientation="vertical"
         aria-label="Größe der Sidebar ändern"
       >
-        <div className="absolute left-0 top-0 bottom-0 w-3 -translate-x-1" />
+        <div className="absolute top-0 bottom-0 left-0 w-3 -translate-x-1" />
       </div>
     )
   },

--- a/app/src/components/regionen/pageRegionSlug/SidebarInspector/ResizeHandle.tsx
+++ b/app/src/components/regionen/pageRegionSlug/SidebarInspector/ResizeHandle.tsx
@@ -13,9 +13,13 @@ export const ResizeHandle = forwardRef<HTMLDivElement, Props>(
         className="fixed top-0 bottom-0 z-30 w-1 cursor-col-resize transition-colors duration-150 hover:bg-purple-500"
         style={{ right: `${inspectorWidth - 1}px` }}
         onMouseDown={onResizeStart}
-        role="separator"
+        role="slider"
         aria-orientation="vertical"
         aria-label="Größe der Sidebar ändern"
+        aria-valuenow={inspectorWidth}
+        aria-valuemin={320}
+        aria-valuemax={800}
+        tabIndex={0}
       >
         <div className="absolute top-0 bottom-0 left-0 w-3 -translate-x-1" />
       </div>

--- a/app/src/components/regionen/pageRegionSlug/SidebarInspector/ResizeHandle.tsx
+++ b/app/src/components/regionen/pageRegionSlug/SidebarInspector/ResizeHandle.tsx
@@ -1,30 +1,25 @@
-import { forwardRef } from 'react'
-
 type Props = {
+  ref?: React.Ref<HTMLDivElement>
   onResizeStart: (e: React.MouseEvent) => void
   inspectorWidth: number
 }
 
-export const ResizeHandle = forwardRef<HTMLDivElement, Props>(
-  ({ onResizeStart, inspectorWidth }, ref) => {
-    return (
-      <div
-        ref={ref}
-        className="fixed top-0 bottom-0 z-30 w-1 cursor-col-resize transition-colors duration-150 hover:bg-purple-500"
-        style={{ right: `${inspectorWidth - 1}px` }}
-        onMouseDown={onResizeStart}
-        role="slider"
-        aria-orientation="vertical"
-        aria-label="Größe der Sidebar ändern"
-        aria-valuenow={inspectorWidth}
-        aria-valuemin={320}
-        aria-valuemax={800}
-        tabIndex={0}
-      >
-        <div className="absolute top-0 bottom-0 left-0 w-3 -translate-x-1" />
-      </div>
-    )
-  },
-)
-
-ResizeHandle.displayName = 'ResizeHandle'
+export const ResizeHandle = ({ ref, onResizeStart, inspectorWidth }: Props) => {
+  return (
+    <div
+      ref={ref}
+      className="fixed top-0 bottom-0 z-30 w-1 cursor-col-resize transition-colors duration-150 hover:bg-purple-500"
+      style={{ right: `${inspectorWidth - 1}px` }}
+      onMouseDown={onResizeStart}
+      role="slider"
+      aria-orientation="vertical"
+      aria-label="Größe der Sidebar ändern"
+      aria-valuenow={inspectorWidth}
+      aria-valuemin={320}
+      aria-valuemax={800}
+      tabIndex={0}
+    >
+      <div className="absolute top-0 bottom-0 left-0 w-3 -translate-x-1" />
+    </div>
+  )
+}

--- a/app/src/components/regionen/pageRegionSlug/SidebarInspector/ResizeHandle.tsx
+++ b/app/src/components/regionen/pageRegionSlug/SidebarInspector/ResizeHandle.tsx
@@ -1,15 +1,12 @@
 type Props = {
-  ref?: React.Ref<HTMLDivElement>
   onResizeStart: (e: React.MouseEvent) => void
   inspectorWidth: number
 }
 
-export const ResizeHandle = ({ ref, onResizeStart, inspectorWidth }: Props) => {
+export const ResizeHandle = ({ onResizeStart, inspectorWidth }: Props) => {
   return (
     <div
-      ref={ref}
-      className="fixed top-0 bottom-0 z-30 w-1 cursor-col-resize transition-colors duration-150 hover:bg-purple-500"
-      style={{ right: `${inspectorWidth - 1}px` }}
+      className="absolute top-0 bottom-0 left-0 z-30 w-1 -translate-x-full cursor-col-resize transition-colors duration-150 hover:bg-purple-500"
       onMouseDown={onResizeStart}
       role="slider"
       aria-orientation="vertical"

--- a/app/src/components/regionen/pageRegionSlug/SidebarInspector/SidebarInspector.tsx
+++ b/app/src/components/regionen/pageRegionSlug/SidebarInspector/SidebarInspector.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { useMap } from 'react-map-gl/maplibre'
 import { twJoin } from 'tailwind-merge'
 import { useInitialSizeMeasurement } from '@/components/regionen/pageRegionSlug/hooks/mapState/useInitialSizeMeasurement'
@@ -44,7 +44,7 @@ export const SidebarInspector = () => {
   const startWidthRef = useRef(0)
   const lastWidthRef = useRef(0)
 
-  const updateWidth = useCallback((width: number) => {
+  const updateWidth = (width: number) => {
     lastWidthRef.current = width
     if (containerRef.current) {
       containerRef.current.style.width = `${width}px`
@@ -55,17 +55,14 @@ export const SidebarInspector = () => {
     if (styleElementRef.current) {
       styleElementRef.current.textContent = `.maplibregl-ctrl-top-right { right: ${width}px } [data-map-controls="true"] { right: calc(${width}px + 10px) }`
     }
-  }, [])
+  }
 
-  const handleResizeStart = useCallback(
-    (e: React.MouseEvent) => {
-      e.preventDefault()
-      setIsResizing(true)
-      startXRef.current = e.clientX
-      startWidthRef.current = inspectorWidth
-    },
-    [inspectorWidth],
-  )
+  const handleResizeStart = (e: React.MouseEvent) => {
+    e.preventDefault()
+    setIsResizing(true)
+    startXRef.current = e.clientX
+    startWidthRef.current = inspectorWidth
+  }
 
   useEffect(() => {
     if (!isResizing) return
@@ -99,13 +96,10 @@ export const SidebarInspector = () => {
   // One-time measurement for initial map-fit visible area (see useInitialSizeMeasurement).
   const initialMeasurementRef = useInitialSizeMeasurement<HTMLDivElement>(updateInspectorSize)
 
-  const ref = useCallback(
-    (node: HTMLDivElement | null) => {
-      containerRef.current = node
-      initialMeasurementRef(node)
-    },
-    [initialMeasurementRef],
-  )
+  const ref = (node: HTMLDivElement | null) => {
+    containerRef.current = node
+    initialMeasurementRef(node)
+  }
 
   useEffect(
     function fitSelectedFeaturesOnceOnLoad() {

--- a/app/src/components/regionen/pageRegionSlug/SidebarInspector/SidebarInspector.tsx
+++ b/app/src/components/regionen/pageRegionSlug/SidebarInspector/SidebarInspector.tsx
@@ -38,7 +38,6 @@ export const SidebarInspector = () => {
   const setInspectorWidth = useInspectorWidthStore((state) => state.setInspectorWidth)
   const [isResizing, setIsResizing] = useState(false)
   const containerRef = useRef<HTMLDivElement | null>(null)
-  const resizeHandleRef = useRef<HTMLDivElement | null>(null)
   const styleElementRef = useRef<HTMLStyleElement | null>(null)
   const startXRef = useRef(0)
   const startWidthRef = useRef(0)
@@ -48,9 +47,6 @@ export const SidebarInspector = () => {
     lastWidthRef.current = width
     if (containerRef.current) {
       containerRef.current.style.width = `${width}px`
-    }
-    if (resizeHandleRef.current) {
-      resizeHandleRef.current.style.right = `${width - 1}px`
     }
     if (styleElementRef.current) {
       styleElementRef.current.textContent = `.maplibregl-ctrl-top-right { right: ${width}px } [data-map-controls="true"] { right: calc(${width}px + 10px) }`
@@ -163,7 +159,7 @@ export const SidebarInspector = () => {
       ref={ref}
       style={{ width: `${inspectorWidth}px` }}
       className={twJoin(
-        'absolute top-0 right-0 bottom-0 z-20 max-w-full overflow-y-scroll bg-white p-5 pr-3 shadow-md',
+        'absolute top-0 right-0 bottom-0 z-20 flex max-w-full flex-col bg-white shadow-md',
         !renderFeatures && 'pointer-events-none opacity-0',
       )}
     >
@@ -175,20 +171,18 @@ export const SidebarInspector = () => {
       )}
       {renderFeatures ? (
         <>
-          <ResizeHandle
-            ref={resizeHandleRef}
-            onResizeStart={handleResizeStart}
-            inspectorWidth={inspectorWidth}
-          />
-          <InspectorHeader count={features.length} handleClose={handleClose} />
-          <Inspector features={features} />
-          <style
-            ref={styleElementRef}
-            // oxlint-disable-next-line react/no-danger -- static CSS for map controls
-            dangerouslySetInnerHTML={{
-              __html: `.maplibregl-ctrl-top-right { right: ${inspectorWidth}px } [data-map-controls="true"] { right: calc(${inspectorWidth}px + 10px) }`,
-            }}
-          />
+          <ResizeHandle onResizeStart={handleResizeStart} inspectorWidth={inspectorWidth} />
+          <div className="flex-1 overflow-y-scroll p-5 pr-3">
+            <InspectorHeader count={features.length} handleClose={handleClose} />
+            <Inspector features={features} />
+            <style
+              ref={styleElementRef}
+              // oxlint-disable-next-line react/no-danger -- static CSS for map controls
+              dangerouslySetInnerHTML={{
+                __html: `.maplibregl-ctrl-top-right { right: ${inspectorWidth}px } [data-map-controls="true"] { right: calc(${inspectorWidth}px + 10px) }`,
+              }}
+            />
+          </div>
         </>
       ) : null}
     </div>

--- a/app/src/components/regionen/pageRegionSlug/SidebarInspector/SidebarInspector.tsx
+++ b/app/src/components/regionen/pageRegionSlug/SidebarInspector/SidebarInspector.tsx
@@ -1,8 +1,9 @@
-import { useEffect, useRef } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { useMap } from 'react-map-gl/maplibre'
 import { twJoin } from 'tailwind-merge'
 import { useInitialSizeMeasurement } from '@/components/regionen/pageRegionSlug/hooks/mapState/useInitialSizeMeasurement'
 import {
+  useInspectorWidthStore,
   useMapActions,
   useMapBounds,
   useMapInspectorFeatures,
@@ -16,6 +17,7 @@ import { useBreakpoint } from '@/components/shared/hooks/viewport/useBreakpoint'
 import { MobileBottomSheet } from '../mobile/MobileBottomSheet'
 import { Inspector } from './Inspector'
 import { InspectorHeader } from './InspectorHeader'
+import { ResizeHandle } from './ResizeHandle'
 import { allUrlFeaturesInBounds, createBoundingPolygon, fitBounds } from './util'
 
 export const SidebarInspector = () => {
@@ -31,8 +33,79 @@ export const SidebarInspector = () => {
   const sidebarSize = useMapSidebarSize()
 
   const { clearInspectorFeatures, updateInspectorSize } = useMapActions()
+
+  const inspectorWidth = useInspectorWidthStore((state) => state.inspectorWidth)
+  const setInspectorWidth = useInspectorWidthStore((state) => state.setInspectorWidth)
+  const [isResizing, setIsResizing] = useState(false)
+  const containerRef = useRef<HTMLDivElement | null>(null)
+  const resizeHandleRef = useRef<HTMLDivElement | null>(null)
+  const styleElementRef = useRef<HTMLStyleElement | null>(null)
+  const startXRef = useRef(0)
+  const startWidthRef = useRef(0)
+  const lastWidthRef = useRef(0)
+
+  const updateWidth = useCallback((width: number) => {
+    lastWidthRef.current = width
+    if (containerRef.current) {
+      containerRef.current.style.width = `${width}px`
+    }
+    if (resizeHandleRef.current) {
+      resizeHandleRef.current.style.right = `${width - 1}px`
+    }
+    if (styleElementRef.current) {
+      styleElementRef.current.textContent = `.maplibregl-ctrl-top-right { right: ${width}px } [data-map-controls="true"] { right: calc(${width}px + 10px) }`
+    }
+  }, [])
+
+  const handleResizeStart = useCallback(
+    (e: React.MouseEvent) => {
+      e.preventDefault()
+      setIsResizing(true)
+      startXRef.current = e.clientX
+      startWidthRef.current = inspectorWidth
+    },
+    [inspectorWidth],
+  )
+
+  useEffect(() => {
+    if (!isResizing) return
+
+    const handleMouseMove = (e: MouseEvent) => {
+      const delta = startXRef.current - e.clientX
+      const newWidth = startWidthRef.current + delta
+      const clampedWidth = Math.min(Math.max(newWidth, 320), 800)
+      updateWidth(clampedWidth)
+    }
+
+    const handleMouseUp = () => {
+      const finalWidth = lastWidthRef.current
+      setInspectorWidth(finalWidth)
+      setIsResizing(false)
+
+      if (containerRef.current) {
+        const height = containerRef.current.offsetHeight
+        updateInspectorSize({ width: finalWidth, height })
+      }
+    }
+
+    document.addEventListener('mousemove', handleMouseMove, { passive: true })
+    document.addEventListener('mouseup', handleMouseUp)
+    return () => {
+      document.removeEventListener('mousemove', handleMouseMove)
+      document.removeEventListener('mouseup', handleMouseUp)
+    }
+  }, [isResizing, setInspectorWidth, updateWidth, updateInspectorSize])
+
   // One-time measurement for initial map-fit visible area (see useInitialSizeMeasurement).
-  const ref = useInitialSizeMeasurement<HTMLDivElement>(updateInspectorSize)
+  const initialMeasurementRef = useInitialSizeMeasurement<HTMLDivElement>(updateInspectorSize)
+
+  const ref = useCallback(
+    (node: HTMLDivElement | null) => {
+      containerRef.current = node
+      initialMeasurementRef(node)
+    },
+    [initialMeasurementRef],
+  )
 
   useEffect(
     function fitSelectedFeaturesOnceOnLoad() {
@@ -94,20 +167,32 @@ export const SidebarInspector = () => {
   return (
     <div
       ref={ref}
+      style={{ width: `${inspectorWidth}px` }}
       className={twJoin(
-        'absolute top-0 right-0 bottom-0 z-20 w-140 max-w-full overflow-y-scroll bg-white p-5 pr-3 shadow-md',
+        'absolute top-0 right-0 bottom-0 z-20 max-w-full overflow-y-scroll bg-white p-5 pr-3 shadow-md',
         !renderFeatures && 'pointer-events-none opacity-0',
       )}
     >
+      {isResizing && (
+        <div
+          className="fixed inset-0 z-50 cursor-col-resize"
+          style={{ background: 'rgba(147, 51, 234, 0.05)' }}
+        />
+      )}
       {renderFeatures ? (
         <>
+          <ResizeHandle
+            ref={resizeHandleRef}
+            onResizeStart={handleResizeStart}
+            inspectorWidth={inspectorWidth}
+          />
           <InspectorHeader count={features.length} handleClose={handleClose} />
           <Inspector features={features} />
           <style
+            ref={styleElementRef}
             // oxlint-disable-next-line react/no-danger -- static CSS for map controls
             dangerouslySetInnerHTML={{
-              __html:
-                '.maplibregl-ctrl-top-right { right: 35rem } [data-map-controls="true"] { right: calc(35rem + 10px) }',
+              __html: `.maplibregl-ctrl-top-right { right: ${inspectorWidth}px } [data-map-controls="true"] { right: calc(${inspectorWidth}px + 10px) }`,
             }}
           />
         </>

--- a/app/src/components/regionen/pageRegionSlug/SidebarInspector/SidebarInspector.tsx
+++ b/app/src/components/regionen/pageRegionSlug/SidebarInspector/SidebarInspector.tsx
@@ -53,13 +53,13 @@ export const SidebarInspector = () => {
     }
   }
 
-  const handleResizeStart = (e: React.MouseEvent) => {
-    e.preventDefault()
-    setIsResizing(true)
-    startXRef.current = e.clientX
-    startWidthRef.current = inspectorWidth
-  }
-
+const handleResizeStart = (e: React.MouseEvent) => {
+  e.preventDefault()
+  setIsResizing(true)
+  startXRef.current = e.clientX
+  startWidthRef.current = inspectorWidth
+  lastWidthRef.current = inspectorWidth
+}
   useEffect(() => {
     if (!isResizing) return
 

--- a/app/src/components/regionen/pageRegionSlug/SidebarInspector/SidebarInspector.tsx
+++ b/app/src/components/regionen/pageRegionSlug/SidebarInspector/SidebarInspector.tsx
@@ -53,13 +53,13 @@ export const SidebarInspector = () => {
     }
   }
 
-const handleResizeStart = (e: React.MouseEvent) => {
-  e.preventDefault()
-  setIsResizing(true)
-  startXRef.current = e.clientX
-  startWidthRef.current = inspectorWidth
-  lastWidthRef.current = inspectorWidth
-}
+  const handleResizeStart = (e: React.MouseEvent) => {
+    e.preventDefault()
+    setIsResizing(true)
+    startXRef.current = e.clientX
+    startWidthRef.current = inspectorWidth
+    lastWidthRef.current = inspectorWidth
+  }
   useEffect(() => {
     if (!isResizing) return
 

--- a/app/src/components/regionen/pageRegionSlug/hooks/mapState/useMapState.ts
+++ b/app/src/components/regionen/pageRegionSlug/hooks/mapState/useMapState.ts
@@ -1,6 +1,7 @@
 import type { LngLatBounds } from 'maplibre-gl'
 import type { MapGeoJSONFeature } from 'react-map-gl/maplibre'
 import { create } from 'zustand'
+import { persist } from 'zustand/middleware'
 import { useShallow } from 'zustand/react/shallow'
 
 const boundsEqual = (current: LngLatBounds | null, next: LngLatBounds | null) => {
@@ -172,3 +173,20 @@ export const useMapDebugSnapshot = () =>
   )
 
 export const useMapActions = () => useMapStore((state) => state.actions)
+
+type InspectorWidthStore = {
+  inspectorWidth: number
+  setInspectorWidth: (width: number) => void
+}
+
+export const useInspectorWidthStore = create<InspectorWidthStore>()(
+  persist(
+    (set) => ({
+      inspectorWidth: 560, // 35rem default
+      setInspectorWidth: (width) => set({ inspectorWidth: width }),
+    }),
+    {
+      name: 'tilda-inspector-width',
+    },
+  ),
+)

--- a/app/src/components/regionen/pageRegionSlug/hooks/mapState/useMapState.ts
+++ b/app/src/components/regionen/pageRegionSlug/hooks/mapState/useMapState.ts
@@ -1,7 +1,7 @@
 import type { LngLatBounds } from 'maplibre-gl'
 import type { MapGeoJSONFeature } from 'react-map-gl/maplibre'
 import { create } from 'zustand'
-import { persist } from 'zustand/middleware'
+import { createJSONStorage, persist } from 'zustand/middleware'
 import { useShallow } from 'zustand/react/shallow'
 
 const boundsEqual = (current: LngLatBounds | null, next: LngLatBounds | null) => {
@@ -187,6 +187,15 @@ export const useInspectorWidthStore = create<InspectorWidthStore>()(
     }),
     {
       name: 'tilda-inspector-width',
+      storage: createJSONStorage(() =>
+        typeof window === 'undefined'
+          ? {
+              getItem: (_name) => null,
+              setItem: (_name, _value) => {},
+              removeItem: (_name) => {},
+            }
+          : localStorage,
+      ),
     },
   ),
 )


### PR DESCRIPTION
_This is a ported version of https://github.com/FixMyBerlin/tilda-geo/pull/264 which is using latest develop branch with TanStack Start als base._

_Original description:_
This PR enables the sidebar to be resizable via a purple line at the edge.

Notable changes:

    Inspector size will be saved in localStorage via zustand for consistent views at tabs and reloads
    Mobile view is not affected

Side effects:

    This makes the Mapillary window notably bigger
