### PR TITLE
Export: Async job-based flow to fix timeouts on large downloads

### DIFF
--- a/app/src/components/regionen/pageRegionSlug/DownloadModal/OgrFormatDownloadLinks.tsx
+++ b/app/src/components/regionen/pageRegionSlug/DownloadModal/OgrFormatDownloadLinks.tsx
@@ -1,6 +1,7 @@
+import { useCallback, useEffect, useState } from 'react'
 import type { SourceExportApiIdentifier } from '@/components/regionen/pageRegionSlug/mapData/mapDataSources/export/exportIdentifier'
-import { Link } from '@/components/shared/links/Link'
-import { getExportOgrApiBboxUrl } from '@/components/shared/utils/getExportApiUrl'
+import { getAppBaseUrl } from '@/components/shared/utils/getAppBaseUrl'
+import { getExportStartApiBboxUrl } from '@/components/shared/utils/getExportApiUrl'
 import type { StaticRegion } from '@/data/regions.const'
 import type { Formats } from '@/server/api/export/ogrFormats.const'
 import { ogrFormats } from '@/server/api/export/ogrFormats.const'
@@ -14,22 +15,128 @@ type Props = {
   bbox: NonNullable<StaticRegion['bbox']>
 }
 
+type Phase = 'idle' | 'running' | 'error'
+const POLL_INTERVAL_MS = 1000
+
+/** Starts an async export job, polls its progress and triggers the browser download when ready. */
+const useFormatExport = (
+  regionSlug: string,
+  tableName: SourceExportApiIdentifier,
+  bbox: NonNullable<StaticRegion['bbox']>,
+  format: Formats,
+) => {
+  const [phase, setPhase] = useState<Phase>('idle')
+  const [percent, setPercent] = useState(0)
+  const [jobId, setJobId] = useState<string | null>(null)
+
+  const triggerDownload = useCallback((id: string) => {
+    const link = document.createElement('a')
+    link.href = getAppBaseUrl(`/api/export-download/${id}`)
+    link.download = ''
+    document.body.appendChild(link)
+    link.click()
+    link.remove()
+  }, [])
+
+  // Poll the running job; the effect cleanup also cancels polling on unmount (e.g. modal closed).
+  useEffect(() => {
+    if (!jobId || phase !== 'running') return
+
+    let cancelled = false
+    const interval = setInterval(async () => {
+      try {
+        const res = await fetch(getAppBaseUrl(`/api/export-status/${jobId}`), {
+          credentials: 'include',
+        })
+        if (!res.ok) throw new Error(`status ${res.status}`)
+        const data: { status: 'running' | 'done' | 'error'; percent: number } = await res.json()
+        if (cancelled) return
+
+        setPercent(data.percent)
+        if (data.status === 'done') {
+          triggerDownload(jobId)
+          setJobId(null)
+          setPhase('idle')
+          setPercent(0)
+        } else if (data.status === 'error') {
+          setJobId(null)
+          setPhase('error')
+        }
+      } catch {
+        if (cancelled) return
+        setJobId(null)
+        setPhase('error')
+      }
+    }, POLL_INTERVAL_MS)
+
+    return () => {
+      cancelled = true
+      clearInterval(interval)
+    }
+  }, [jobId, phase, triggerDownload])
+
+  const start = useCallback(async () => {
+    setPhase('running')
+    setPercent(0)
+    try {
+      const res = await fetch(getExportStartApiBboxUrl(regionSlug, tableName, bbox, format), {
+        credentials: 'include',
+      })
+      if (!res.ok) throw new Error(`start ${res.status}`)
+      const { jobId: newJobId } = (await res.json()) as { jobId: string }
+      setJobId(newJobId)
+    } catch {
+      setPhase('error')
+    }
+  }, [regionSlug, tableName, bbox, format])
+
+  return { phase, percent, start }
+}
+
+const OgrFormatDownloadButton = ({
+  regionSlug,
+  tableName,
+  bbox,
+  format,
+  driver,
+}: Props & { format: Formats; driver: string }) => {
+  const { phase, percent, start } = useFormatExport(regionSlug, tableName, bbox, format)
+
+  return (
+    <button
+      type="button"
+      onClick={start}
+      disabled={phase === 'running'}
+      className={`${downloadFormatLinkClasses} relative overflow-hidden disabled:cursor-progress`}
+    >
+      <strong className="mb-0.5 block text-xs font-medium text-gray-500">
+        {phase === 'running' ? `${percent} %` : phase === 'error' ? 'Fehler' : 'Download'}
+      </strong>
+      <span className="block border-0 p-0 font-mono text-gray-900 focus:ring-0 sm:text-sm">
+        {phase === 'error' ? 'Erneut versuchen' : driver}
+      </span>
+      {phase === 'running' && (
+        <span
+          className="absolute bottom-0 left-0 h-1 bg-yellow-500 transition-[width] duration-300"
+          style={{ width: `${percent}%` }}
+        />
+      )}
+    </button>
+  )
+}
+
 export const OgrFormatDownloadLinks = ({ regionSlug, tableName, bbox }: Props) => {
   return (
     <>
       {Object.entries(ogrFormats).map(([param, format]) => (
-        <Link
+        <OgrFormatDownloadButton
           key={param}
-          href={getExportOgrApiBboxUrl(regionSlug, tableName, bbox, param as Formats)}
-          classNameOverwrite={downloadFormatLinkClasses}
-          download
-          blank
-        >
-          <strong className="mb-0.5 block text-xs font-medium text-gray-500">Download</strong>
-          <span className="block border-0 p-0 font-mono text-gray-900 focus:ring-0 sm:text-sm">
-            {format.driver}
-          </span>
-        </Link>
+          regionSlug={regionSlug}
+          tableName={tableName}
+          bbox={bbox}
+          format={param as Formats}
+          driver={format.driver}
+        />
       ))}
     </>
   )

--- a/app/src/components/shared/utils/getExportApiUrl.ts
+++ b/app/src/components/shared/utils/getExportApiUrl.ts
@@ -36,3 +36,25 @@ export const getExportOgrApiBboxUrl = (
   const baseUrl = getExportApiBboxUrl(regionSlug, apiIdentifier, bbox, env, apiKey)
   return `${baseUrl}&format=${format}`
 }
+
+// Async export: starts a background job (returns a job id) which the UI then polls
+// and finally downloads. Mirrors `getExportOgrApiBboxUrl` but hits `/api/export-start`.
+export const getExportStartApiBboxUrl = (
+  regionSlug: string,
+  apiIdentifier: SourceExportApiIdentifier,
+  bbox: NonNullable<StaticRegion['bbox']>,
+  format: 'geojson' | 'gpkg' | 'fgb' = 'fgb',
+  env?: EnvironmentValues,
+  apiKey?: string,
+) => {
+  const url = new URL(getAppBaseUrl(`/api/export-start/${regionSlug}/${apiIdentifier}`, env))
+  url.searchParams.append('minlon', String(bbox.min[0]))
+  url.searchParams.append('minlat', String(bbox.min[1]))
+  url.searchParams.append('maxlon', String(bbox.max[0]))
+  url.searchParams.append('maxlat', String(bbox.max[1]))
+  url.searchParams.append('format', format)
+  if (apiKey) {
+    url.searchParams.append('apiKey', apiKey)
+  }
+  return url.toString()
+}

--- a/app/src/routeTree.gen.ts
+++ b/app/src/routeTree.gen.ts
@@ -58,6 +58,8 @@ import { Route as ApiPrivatePostProcessingHookRouteImport } from './routes/api/p
 import { Route as ApiPrivateGenerateMaprouletteTasksRouteImport } from './routes/api/private/generate-maproulette-tasks'
 import { Route as ApiOsmNotesRssRouteImport } from './routes/api/osm-notes.rss'
 import { Route as ApiNotesRegionSlugRouteImport } from './routes/api/notes.$regionSlug'
+import { Route as ApiExportStatusJobIdRouteImport } from './routes/api/export-status.$jobId'
+import { Route as ApiExportDownloadJobIdRouteImport } from './routes/api/export-download.$jobId'
 import { Route as ApiAuthSplatRouteImport } from './routes/api/auth.$'
 import { Route as AdminUploadsSlugRouteImport } from './routes/admin/uploads/$slug'
 import { Route as AdminStaticDatasetCategoriesNewRouteImport } from './routes/admin/static-dataset-categories/new'
@@ -77,6 +79,7 @@ import { Route as ApiMaprouletteDataTest_tag_fix_cyclewaySharedRouteImport } fro
 import { Route as ApiMaprouletteDataTest_tag_fixRouteImport } from './routes/api/maproulette.data.test_tag_fix'
 import { Route as ApiMaprouletteDataProjectKeyRouteImport } from './routes/api/maproulette.data.$projectKey'
 import { Route as ApiExportRegionSlugTableNameRouteImport } from './routes/api/export.$regionSlug.$tableName'
+import { Route as ApiExportStartRegionSlugTableNameRouteImport } from './routes/api/export-start.$regionSlug.$tableName'
 import { Route as ApiExportOgrRegionSlugTableNameRouteImport } from './routes/api/export-ogr.$regionSlug.$tableName'
 import { Route as AdminRegionsRegionSlugEditRouteImport } from './routes/admin/regions/$regionSlug.edit'
 import { Route as AdminQaConfigsIdEditRouteImport } from './routes/admin/qa-configs/$id.edit'
@@ -333,6 +336,16 @@ const ApiNotesRegionSlugRoute = ApiNotesRegionSlugRouteImport.update({
   path: '/api/notes/$regionSlug',
   getParentRoute: () => rootRouteImport,
 } as any)
+const ApiExportStatusJobIdRoute = ApiExportStatusJobIdRouteImport.update({
+  id: '/api/export-status/$jobId',
+  path: '/api/export-status/$jobId',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiExportDownloadJobIdRoute = ApiExportDownloadJobIdRouteImport.update({
+  id: '/api/export-download/$jobId',
+  path: '/api/export-download/$jobId',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ApiAuthSplatRoute = ApiAuthSplatRouteImport.update({
   id: '/api/auth/$',
   path: '/api/auth/$',
@@ -439,6 +452,12 @@ const ApiExportRegionSlugTableNameRoute =
     path: '/api/export/$regionSlug/$tableName',
     getParentRoute: () => rootRouteImport,
   } as any)
+const ApiExportStartRegionSlugTableNameRoute =
+  ApiExportStartRegionSlugTableNameRouteImport.update({
+    id: '/api/export-start/$regionSlug/$tableName',
+    path: '/api/export-start/$regionSlug/$tableName',
+    getParentRoute: () => rootRouteImport,
+  } as any)
 const ApiExportOgrRegionSlugTableNameRoute =
   ApiExportOgrRegionSlugTableNameRouteImport.update({
     id: '/api/export-ogr/$regionSlug/$tableName',
@@ -507,6 +526,8 @@ export interface FileRoutesByFullPath {
   '/admin/static-dataset-categories/new': typeof AdminStaticDatasetCategoriesNewRoute
   '/admin/uploads/$slug': typeof AdminUploadsSlugRoute
   '/api/auth/$': typeof ApiAuthSplatRoute
+  '/api/export-download/$jobId': typeof ApiExportDownloadJobIdRoute
+  '/api/export-status/$jobId': typeof ApiExportStatusJobIdRoute
   '/api/notes/$regionSlug': typeof ApiNotesRegionSlugRouteWithChildren
   '/api/osm-notes/rss': typeof ApiOsmNotesRssRoute
   '/api/private/generate-maproulette-tasks': typeof ApiPrivateGenerateMaprouletteTasksRoute
@@ -526,6 +547,7 @@ export interface FileRoutesByFullPath {
   '/admin/qa-configs/$id/edit': typeof AdminQaConfigsIdEditRoute
   '/admin/regions/$regionSlug/edit': typeof AdminRegionsRegionSlugEditRoute
   '/api/export-ogr/$regionSlug/$tableName': typeof ApiExportOgrRegionSlugTableNameRoute
+  '/api/export-start/$regionSlug/$tableName': typeof ApiExportStartRegionSlugTableNameRoute
   '/api/export/$regionSlug/$tableName': typeof ApiExportRegionSlugTableNameRoute
   '/api/maproulette/data/$projectKey': typeof ApiMaprouletteDataProjectKeyRoute
   '/api/maproulette/data/test_tag_fix': typeof ApiMaprouletteDataTest_tag_fixRoute
@@ -572,6 +594,8 @@ export interface FileRoutesByTo {
   '/admin/static-dataset-categories/new': typeof AdminStaticDatasetCategoriesNewRoute
   '/admin/uploads/$slug': typeof AdminUploadsSlugRoute
   '/api/auth/$': typeof ApiAuthSplatRoute
+  '/api/export-download/$jobId': typeof ApiExportDownloadJobIdRoute
+  '/api/export-status/$jobId': typeof ApiExportStatusJobIdRoute
   '/api/notes/$regionSlug': typeof ApiNotesRegionSlugRouteWithChildren
   '/api/osm-notes/rss': typeof ApiOsmNotesRssRoute
   '/api/private/generate-maproulette-tasks': typeof ApiPrivateGenerateMaprouletteTasksRoute
@@ -591,6 +615,7 @@ export interface FileRoutesByTo {
   '/admin/qa-configs/$id/edit': typeof AdminQaConfigsIdEditRoute
   '/admin/regions/$regionSlug/edit': typeof AdminRegionsRegionSlugEditRoute
   '/api/export-ogr/$regionSlug/$tableName': typeof ApiExportOgrRegionSlugTableNameRoute
+  '/api/export-start/$regionSlug/$tableName': typeof ApiExportStartRegionSlugTableNameRoute
   '/api/export/$regionSlug/$tableName': typeof ApiExportRegionSlugTableNameRoute
   '/api/maproulette/data/$projectKey': typeof ApiMaprouletteDataProjectKeyRoute
   '/api/maproulette/data/test_tag_fix': typeof ApiMaprouletteDataTest_tag_fixRoute
@@ -647,6 +672,8 @@ export interface FileRoutesById {
   '/admin/static-dataset-categories/new': typeof AdminStaticDatasetCategoriesNewRoute
   '/admin/uploads/$slug': typeof AdminUploadsSlugRoute
   '/api/auth/$': typeof ApiAuthSplatRoute
+  '/api/export-download/$jobId': typeof ApiExportDownloadJobIdRoute
+  '/api/export-status/$jobId': typeof ApiExportStatusJobIdRoute
   '/api/notes/$regionSlug': typeof ApiNotesRegionSlugRouteWithChildren
   '/api/osm-notes/rss': typeof ApiOsmNotesRssRoute
   '/api/private/generate-maproulette-tasks': typeof ApiPrivateGenerateMaprouletteTasksRoute
@@ -666,6 +693,7 @@ export interface FileRoutesById {
   '/admin/qa-configs/$id/edit': typeof AdminQaConfigsIdEditRoute
   '/admin/regions/$regionSlug/edit': typeof AdminRegionsRegionSlugEditRoute
   '/api/export-ogr/$regionSlug/$tableName': typeof ApiExportOgrRegionSlugTableNameRoute
+  '/api/export-start/$regionSlug/$tableName': typeof ApiExportStartRegionSlugTableNameRoute
   '/api/export/$regionSlug/$tableName': typeof ApiExportRegionSlugTableNameRoute
   '/api/maproulette/data/$projectKey': typeof ApiMaprouletteDataProjectKeyRoute
   '/api/maproulette/data/test_tag_fix': typeof ApiMaprouletteDataTest_tag_fixRoute
@@ -722,6 +750,8 @@ export interface FileRouteTypes {
     | '/admin/static-dataset-categories/new'
     | '/admin/uploads/$slug'
     | '/api/auth/$'
+    | '/api/export-download/$jobId'
+    | '/api/export-status/$jobId'
     | '/api/notes/$regionSlug'
     | '/api/osm-notes/rss'
     | '/api/private/generate-maproulette-tasks'
@@ -741,6 +771,7 @@ export interface FileRouteTypes {
     | '/admin/qa-configs/$id/edit'
     | '/admin/regions/$regionSlug/edit'
     | '/api/export-ogr/$regionSlug/$tableName'
+    | '/api/export-start/$regionSlug/$tableName'
     | '/api/export/$regionSlug/$tableName'
     | '/api/maproulette/data/$projectKey'
     | '/api/maproulette/data/test_tag_fix'
@@ -787,6 +818,8 @@ export interface FileRouteTypes {
     | '/admin/static-dataset-categories/new'
     | '/admin/uploads/$slug'
     | '/api/auth/$'
+    | '/api/export-download/$jobId'
+    | '/api/export-status/$jobId'
     | '/api/notes/$regionSlug'
     | '/api/osm-notes/rss'
     | '/api/private/generate-maproulette-tasks'
@@ -806,6 +839,7 @@ export interface FileRouteTypes {
     | '/admin/qa-configs/$id/edit'
     | '/admin/regions/$regionSlug/edit'
     | '/api/export-ogr/$regionSlug/$tableName'
+    | '/api/export-start/$regionSlug/$tableName'
     | '/api/export/$regionSlug/$tableName'
     | '/api/maproulette/data/$projectKey'
     | '/api/maproulette/data/test_tag_fix'
@@ -861,6 +895,8 @@ export interface FileRouteTypes {
     | '/admin/static-dataset-categories/new'
     | '/admin/uploads/$slug'
     | '/api/auth/$'
+    | '/api/export-download/$jobId'
+    | '/api/export-status/$jobId'
     | '/api/notes/$regionSlug'
     | '/api/osm-notes/rss'
     | '/api/private/generate-maproulette-tasks'
@@ -880,6 +916,7 @@ export interface FileRouteTypes {
     | '/admin/qa-configs/$id/edit'
     | '/admin/regions/$regionSlug/edit'
     | '/api/export-ogr/$regionSlug/$tableName'
+    | '/api/export-start/$regionSlug/$tableName'
     | '/api/export/$regionSlug/$tableName'
     | '/api/maproulette/data/$projectKey'
     | '/api/maproulette/data/test_tag_fix'
@@ -906,6 +943,8 @@ export interface RootRouteChildren {
   ApiStatsRoute: typeof ApiStatsRoute
   ApiUploadsRoute: typeof ApiUploadsRouteWithChildren
   ApiAuthSplatRoute: typeof ApiAuthSplatRoute
+  ApiExportDownloadJobIdRoute: typeof ApiExportDownloadJobIdRoute
+  ApiExportStatusJobIdRoute: typeof ApiExportStatusJobIdRoute
   ApiNotesRegionSlugRoute: typeof ApiNotesRegionSlugRouteWithChildren
   ApiOsmNotesRssRoute: typeof ApiOsmNotesRssRoute
   ApiPrivateGenerateMaprouletteTasksRoute: typeof ApiPrivateGenerateMaprouletteTasksRoute
@@ -915,6 +954,7 @@ export interface RootRouteChildren {
   ApiPrivateWarmCacheRoute: typeof ApiPrivateWarmCacheRoute
   ApiSignInOsmRoute: typeof ApiSignInOsmRoute
   ApiExportOgrRegionSlugTableNameRoute: typeof ApiExportOgrRegionSlugTableNameRoute
+  ApiExportStartRegionSlugTableNameRoute: typeof ApiExportStartRegionSlugTableNameRoute
   ApiExportRegionSlugTableNameRoute: typeof ApiExportRegionSlugTableNameRoute
   ApiMaprouletteDataProjectKeyRoute: typeof ApiMaprouletteDataProjectKeyRoute
   ApiMaprouletteDataTest_tag_fixRoute: typeof ApiMaprouletteDataTest_tag_fixRoute
@@ -1269,6 +1309,20 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ApiNotesRegionSlugRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/api/export-status/$jobId': {
+      id: '/api/export-status/$jobId'
+      path: '/api/export-status/$jobId'
+      fullPath: '/api/export-status/$jobId'
+      preLoaderRoute: typeof ApiExportStatusJobIdRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/export-download/$jobId': {
+      id: '/api/export-download/$jobId'
+      path: '/api/export-download/$jobId'
+      fullPath: '/api/export-download/$jobId'
+      preLoaderRoute: typeof ApiExportDownloadJobIdRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/api/auth/$': {
       id: '/api/auth/$'
       path: '/api/auth/$'
@@ -1400,6 +1454,13 @@ declare module '@tanstack/react-router' {
       path: '/api/export/$regionSlug/$tableName'
       fullPath: '/api/export/$regionSlug/$tableName'
       preLoaderRoute: typeof ApiExportRegionSlugTableNameRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/export-start/$regionSlug/$tableName': {
+      id: '/api/export-start/$regionSlug/$tableName'
+      path: '/api/export-start/$regionSlug/$tableName'
+      fullPath: '/api/export-start/$regionSlug/$tableName'
+      preLoaderRoute: typeof ApiExportStartRegionSlugTableNameRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/api/export-ogr/$regionSlug/$tableName': {
@@ -1660,6 +1721,8 @@ const rootRouteChildren: RootRouteChildren = {
   ApiStatsRoute: ApiStatsRoute,
   ApiUploadsRoute: ApiUploadsRouteWithChildren,
   ApiAuthSplatRoute: ApiAuthSplatRoute,
+  ApiExportDownloadJobIdRoute: ApiExportDownloadJobIdRoute,
+  ApiExportStatusJobIdRoute: ApiExportStatusJobIdRoute,
   ApiNotesRegionSlugRoute: ApiNotesRegionSlugRouteWithChildren,
   ApiOsmNotesRssRoute: ApiOsmNotesRssRoute,
   ApiPrivateGenerateMaprouletteTasksRoute:
@@ -1670,6 +1733,8 @@ const rootRouteChildren: RootRouteChildren = {
   ApiPrivateWarmCacheRoute: ApiPrivateWarmCacheRoute,
   ApiSignInOsmRoute: ApiSignInOsmRoute,
   ApiExportOgrRegionSlugTableNameRoute: ApiExportOgrRegionSlugTableNameRoute,
+  ApiExportStartRegionSlugTableNameRoute:
+    ApiExportStartRegionSlugTableNameRoute,
   ApiExportRegionSlugTableNameRoute: ApiExportRegionSlugTableNameRoute,
   ApiMaprouletteDataProjectKeyRoute: ApiMaprouletteDataProjectKeyRoute,
   ApiMaprouletteDataTest_tag_fixRoute: ApiMaprouletteDataTest_tag_fixRoute,

--- a/app/src/routes/api/export-download.$jobId.ts
+++ b/app/src/routes/api/export-download.$jobId.ts
@@ -1,0 +1,42 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { getExportJob, removeExportJob } from '@/server/api/export/exportJobs.server'
+import { createExportFileResponseStream } from '@/server/api/export/streamExportFile.server'
+import { notFoundJson } from '@/server/api/util/apiJsonResponses.server'
+import { corsHeaders } from '@/server/api/util/cors'
+
+export const Route = createFileRoute('/api/export-download/$jobId')({
+  ssr: true,
+  server: {
+    handlers: {
+      // Streams the finished file from disk, then deletes the temp file and the job.
+      GET: ({ params }) => {
+        const job = getExportJob(params.jobId)
+        if (!job || job.status !== 'done' || !job.outputFilePath || job.outputBytes == null) {
+          return notFoundJson({
+            headers: corsHeaders,
+            message: 'Export not ready, expired or not found',
+          })
+        }
+
+        const logPrefix = `[EXPORT-JOB:${job.id}]`
+
+        return new Response(
+          createExportFileResponseStream({
+            outputFilePath: job.outputFilePath,
+            logPrefix,
+            requestStartedAt: Date.now(),
+            onFinalized: () => removeExportJob(job.id),
+          }),
+          {
+            headers: {
+              ...corsHeaders,
+              'Content-Type': job.mimeType ?? 'application/octet-stream',
+              'Content-Length': job.outputBytes.toString(),
+              'Content-Disposition': `attachment; filename="${job.filename}"`,
+            },
+          },
+        )
+      },
+    },
+  },
+})

--- a/app/src/routes/api/export-start.$regionSlug.$tableName.ts
+++ b/app/src/routes/api/export-start.$regionSlug.$tableName.ts
@@ -1,0 +1,89 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { z } from 'zod'
+import {
+  createExportJob,
+  removeExportJob,
+  updateExportJob,
+} from '@/server/api/export/exportJobs.server'
+import {
+  buildExportFilename,
+  exportParamsSchema,
+  parseExportSearch,
+} from '@/server/api/export/exportRequest.server'
+import { generateExport } from '@/server/api/export/generateExport.server'
+import {
+  badRequestJson,
+  forbiddenJson,
+  notFoundJson,
+} from '@/server/api/util/apiJsonResponses.server'
+import { resolveRegionAccessStatus } from '@/server/api/util/authGuards.server'
+import { corsHeaders } from '@/server/api/util/cors'
+
+export const Route = createFileRoute('/api/export-start/$regionSlug/$tableName')({
+  ssr: true,
+  params: {
+    parse: (rawParams) => exportParamsSchema.parse(rawParams),
+  },
+  server: {
+    handlers: {
+      // Starts a background export and returns a job id. The client then polls
+      // `/api/export-status/$jobId` and finally downloads `/api/export-download/$jobId`.
+      GET: async ({ request, params }) => {
+        const rawSearchParams = new URL(request.url).searchParams
+        const parsedSearch = parseExportSearch(rawSearchParams)
+        if (!parsedSearch.success) {
+          return badRequestJson({ headers: corsHeaders, info: z.flattenError(parsedSearch.error) })
+        }
+
+        const { regionSlug, tableName } = params
+        const { apiKey, format, ...bbox } = parsedSearch.data
+
+        const status = await resolveRegionAccessStatus({
+          headers: request.headers,
+          regionSlug,
+          apiKey,
+        })
+        if (status !== 200) {
+          return status === 404
+            ? notFoundJson({ headers: corsHeaders })
+            : forbiddenJson({ headers: corsHeaders })
+        }
+
+        const filename = await buildExportFilename(tableName, format)
+        const job = createExportJob(filename)
+        const logPrefix = `[EXPORT-JOB:${job.id}]`
+        console.info(logPrefix, 'start export', { regionSlug, tableName, format, bbox })
+
+        // Fire-and-forget: generation runs in the background, progress is pushed into the job.
+        void generateExport({
+          tableName,
+          regionSlug,
+          format,
+          bbox,
+          logPrefix,
+          onProgress: (percent) => updateExportJob(job.id, { percent }),
+        })
+          .then(({ outputFilePath, outputBytes, mimeType }) => {
+            updateExportJob(job.id, {
+              status: 'done',
+              percent: 100,
+              outputFilePath,
+              outputBytes,
+              mimeType,
+            })
+          })
+          .catch((error) => {
+            console.error(logPrefix, 'export generation failed', { error })
+            updateExportJob(job.id, {
+              status: 'error',
+              error: error instanceof Error ? error.message : 'Export failed',
+            })
+            // Drop the failed job after a short grace period so the client can read the error.
+            setTimeout(() => removeExportJob(job.id), 60_000).unref?.()
+          })
+
+        return Response.json({ jobId: job.id, filename }, { headers: corsHeaders })
+      },
+    },
+  },
+})

--- a/app/src/routes/api/export-status.$jobId.ts
+++ b/app/src/routes/api/export-status.$jobId.ts
@@ -1,0 +1,28 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { getExportJob } from '@/server/api/export/exportJobs.server'
+import { notFoundJson } from '@/server/api/util/apiJsonResponses.server'
+import { corsHeaders } from '@/server/api/util/cors'
+
+export const Route = createFileRoute('/api/export-status/$jobId')({
+  ssr: true,
+  server: {
+    handlers: {
+      // Polled by the client to drive the progress bar.
+      GET: ({ params }) => {
+        const job = getExportJob(params.jobId)
+        if (!job) {
+          return notFoundJson({ headers: corsHeaders, message: 'Export job not found or expired' })
+        }
+        return Response.json(
+          {
+            status: job.status,
+            percent: job.percent,
+            filename: job.filename,
+            ...(job.status === 'error' ? { error: job.error } : {}),
+          },
+          { headers: corsHeaders },
+        )
+      },
+    },
+  },
+})

--- a/app/src/routes/api/export.$regionSlug.$tableName.ts
+++ b/app/src/routes/api/export.$regionSlug.$tableName.ts
@@ -1,14 +1,12 @@
-import { exec, execFile } from 'node:child_process'
-import { createReadStream } from 'node:fs'
-import fs from 'node:fs/promises'
-import path from 'node:path'
 import { createFileRoute } from '@tanstack/react-router'
 import { z } from 'zod'
-import { exportApiIdentifier } from '@/components/regionen/pageRegionSlug/mapData/mapDataSources/export/exportIdentifier'
-import { formatDateBerlin } from '@/components/shared/date/formatDateBerlin'
-import { isDev } from '@/components/shared/utils/isEnv'
-import { getExportAttributeType } from '@/server/api/export/exportAttributeType'
-import { formats, ogrFormats } from '@/server/api/export/ogrFormats.const'
+import {
+  buildExportFilename,
+  exportParamsSchema,
+  parseExportSearch,
+} from '@/server/api/export/exportRequest.server'
+import { generateExport } from '@/server/api/export/generateExport.server'
+import { createExportFileResponseStream } from '@/server/api/export/streamExportFile.server'
 import {
   badRequestJson,
   forbiddenJson,
@@ -17,143 +15,9 @@ import {
 } from '@/server/api/util/apiJsonResponses.server'
 import { resolveRegionAccessStatus } from '@/server/api/util/authGuards.server'
 import { corsHeaders } from '@/server/api/util/cors'
-import { getProcessingMeta } from '@/server/api/util/getProcessingMeta.server'
-import { getBaseDatabaseUrl } from '@/server/database-url.server'
-import { geoDataClient } from '@/server/prisma-client.server'
-
-const exportMetadata = {
-  licence: 'ODbL',
-  attribution: '(c) OpenStreetMap; tilda-geo.de',
-  owner: 'FixMyCity GmbH / TILDA Geo',
-}
-
-let gdalVersionCheckPromise: Promise<boolean> | null = null
-let hasLoggedUnsupportedGdalVersion = false
-
-async function checkGdalVersion() {
-  if (gdalVersionCheckPromise) return gdalVersionCheckPromise
-
-  gdalVersionCheckPromise = new Promise<boolean>((resolve) => {
-    exec('gdalinfo --version', { timeout: 5000 }, (error, stdout) => {
-      if (error) {
-        console.warn('[EXPORT] GDAL version check failed:', error.message)
-        resolve(false)
-        return
-      }
-
-      const versionMatch = stdout.match(/GDAL (\d+)\.(\d+)\.(\d+)/)
-      if (!versionMatch) {
-        console.warn('[EXPORT] Could not parse GDAL version from:', stdout)
-        resolve(false)
-        return
-      }
-
-      const major = parseInt(versionMatch[1] || '0', 10)
-      const minor = parseInt(versionMatch[2] || '0', 10)
-      const hasRequiredVersion = major > 3 || (major === 3 && minor >= 11)
-
-      if (!hasRequiredVersion && !hasLoggedUnsupportedGdalVersion) {
-        console.info(
-          `[EXPORT] GDAL version ${versionMatch[0]} does not support metadata-enrichment step (requires 3.11+). Export generation continues without metadata edits.`,
-        )
-        hasLoggedUnsupportedGdalVersion = true
-      }
-
-      resolve(hasRequiredVersion)
-    })
-  })
-
-  try {
-    return await gdalVersionCheckPromise
-  } catch (error) {
-    console.warn('[EXPORT] GDAL version check error:', error)
-    gdalVersionCheckPromise = null
-    return false
-  }
-}
-
-const exportParamsSchema = z.object({
-  regionSlug: z.string(),
-  tableName: z.enum(exportApiIdentifier),
-})
-
-const exportSearchSchema = z.object({
-  apiKey: z.string().optional(),
-  minlon: z.coerce.number(),
-  minlat: z.coerce.number(),
-  maxlon: z.coerce.number(),
-  maxlat: z.coerce.number(),
-  format: z.enum(formats),
-})
 
 const createExportRunId = () =>
   `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`
-
-const unlinkExportFile = async (outputFilePath: string, logPrefix: string, reason: string) => {
-  try {
-    await fs.unlink(outputFilePath)
-  } catch (unlinkError) {
-    console.warn(logPrefix, 'failed to remove temp export file', {
-      outputFilePath,
-      reason,
-      unlinkError,
-    })
-  }
-}
-
-const createExportFileResponseStream = ({
-  outputFilePath,
-  logPrefix,
-  requestStartedAt,
-}: {
-  outputFilePath: string
-  logPrefix: string
-  requestStartedAt: number
-}) => {
-  const nodeStream = createReadStream(outputFilePath)
-  let bytesStreamed = 0
-  let didCleanup = false
-  const cleanupFile = (reason: string) => {
-    if (didCleanup) return
-    didCleanup = true
-    void unlinkExportFile(outputFilePath, logPrefix, reason)
-  }
-
-  return new ReadableStream<Uint8Array>({
-    start(controller) {
-      nodeStream.on('data', (chunk: Buffer) => {
-        bytesStreamed += chunk.length
-        controller.enqueue(new Uint8Array(chunk))
-      })
-      nodeStream.on('end', () => {
-        controller.close()
-        console.info(logPrefix, 'stream completed', {
-          bytesStreamed,
-          totalDurationMs: Date.now() - requestStartedAt,
-        })
-        cleanupFile('stream_completed')
-      })
-      nodeStream.on('error', (streamError) => {
-        console.error(logPrefix, 'stream failed', {
-          bytesStreamed,
-          totalDurationMs: Date.now() - requestStartedAt,
-          streamError,
-        })
-        controller.error(streamError)
-        cleanupFile('stream_failed')
-      })
-    },
-    cancel(cancelReason) {
-      nodeStream.destroy()
-      console.warn(logPrefix, 'stream canceled by client', {
-        bytesStreamed,
-        totalDurationMs: Date.now() - requestStartedAt,
-        cancelReason,
-      })
-      cleanupFile('stream_canceled')
-    },
-  })
-}
 
 export const Route = createFileRoute('/api/export/$regionSlug/$tableName')({
   ssr: true,
@@ -162,40 +26,25 @@ export const Route = createFileRoute('/api/export/$regionSlug/$tableName')({
   },
   server: {
     handlers: {
+      // Synchronous direct download (public API / direct URL use). For large regions
+      // the in-app UI uses the async job flow (`/api/export-start`) to avoid timeouts.
       GET: async ({ request, params }) => {
         const exportRunId = createExportRunId()
         const logPrefix = `[EXPORT:${exportRunId}]`
         const requestStartedAt = Date.now()
-        const rawSearchParams = new URL(request.url).searchParams
-        const parsedSearch = exportSearchSchema.safeParse({
-          apiKey: rawSearchParams.get('apiKey') || '',
-          minlon: rawSearchParams.get('minlon'),
-          minlat: rawSearchParams.get('minlat'),
-          maxlon: rawSearchParams.get('maxlon'),
-          maxlat: rawSearchParams.get('maxlat'),
-          format: rawSearchParams.get('format') || 'fgb',
-        })
+        const parsedSearch = parseExportSearch(new URL(request.url).searchParams)
 
         if (!parsedSearch.success) {
           console.error(logPrefix, 'invalid export query params', {
             url: request.url,
             issues: parsedSearch.error.issues,
           })
-          return badRequestJson({
-            headers: corsHeaders,
-            info: z.flattenError(parsedSearch.error),
-          })
+          return badRequestJson({ headers: corsHeaders, info: z.flattenError(parsedSearch.error) })
         }
+
         const { regionSlug, tableName } = params
-        const { apiKey, minlon, minlat, maxlon, maxlat, format } = parsedSearch.data
-        console.info(logPrefix, 'start export', {
-          regionSlug,
-          tableName,
-          format,
-          bbox: { minlon, minlat, maxlon, maxlat },
-          hasApiKey: Boolean(apiKey),
-          requestId: request.headers.get('x-request-id') || undefined,
-        })
+        const { apiKey, format, ...bbox } = parsedSearch.data
+        console.info(logPrefix, 'start export', { regionSlug, tableName, format, bbox })
 
         const status = await resolveRegionAccessStatus({
           headers: request.headers,
@@ -204,222 +53,43 @@ export const Route = createFileRoute('/api/export/$regionSlug/$tableName')({
         })
         if (status !== 200) {
           console.warn(logPrefix, 'access denied', { status, regionSlug, tableName })
-          if (status === 404) {
-            return notFoundJson({ headers: corsHeaders })
-          }
-          return forbiddenJson({ headers: corsHeaders })
+          return status === 404
+            ? notFoundJson({ headers: corsHeaders })
+            : forbiddenJson({ headers: corsHeaders })
         }
 
         try {
-          const tagKeysStartedAt = Date.now()
-          const tagKeyQuery: Array<{ key: string }> = await geoDataClient.$queryRawUnsafe(`
-              SELECT DISTINCT jsonb_object_keys(tags) AS key
-              FROM "${tableName}"
-            `)
-          const metaKeysStartedAt = Date.now()
-          const metaKeyQuery: Array<{ key: string }> = await geoDataClient.$queryRawUnsafe(`
-              SELECT DISTINCT jsonb_object_keys(meta) AS key
-              FROM "${tableName}"
-            `)
-          const columnsCheckStartedAt = Date.now()
-
-          const columnExistsQuery: Array<{ column_name: string }> =
-            await geoDataClient.$queryRawUnsafe(`
-              SELECT column_name
-              FROM information_schema.columns
-              WHERE table_name = '${tableName}'
-              AND column_name IN ('osm_id', 'osm_type')
-            `)
-          const existingColumns = columnExistsQuery.map(({ column_name }) => column_name)
-          const hasOsmId = existingColumns.includes('osm_id')
-          const hasOsmType = existingColumns.includes('osm_type')
-          const columnsMetadataTimingsMs = {
-            tagKeys: metaKeysStartedAt - tagKeysStartedAt,
-            metaKeys: columnsCheckStartedAt - metaKeysStartedAt,
-            columnsCheck: Date.now() - columnsCheckStartedAt,
-          }
-
-          const sanitizeKey = (key: string) => key.replace(/[^a-z]/gi, '_')
-          const generateColumn = (key: string, columnType: 'tags' | 'meta') => {
-            const attributeType = getExportAttributeType(key)
-            const sanitizedKey = sanitizeKey(key)
-
-            return attributeType === 'number'
-              ? `CAST(${columnType}->>'${key}' AS numeric) AS "${sanitizedKey}"`
-              : `${columnType}->>'${key}' AS "${sanitizedKey}"`
-          }
-
-          const columns = [
-            'id',
-            'geom',
-            hasOsmId ? 'osm_id' : undefined,
-            hasOsmType ? 'osm_type' : undefined,
-            ...tagKeyQuery.map(({ key }) => generateColumn(key, 'tags')),
-            ...metaKeyQuery.map(({ key }) => generateColumn(key, 'meta')),
-          ]
-            .filter(Boolean)
-            .join(',\n')
-
-          const sqlQuery = `
-            SELECT ${columns}
-            FROM public."${tableName}"
-            WHERE geom && ST_Transform(
-              (SELECT ST_SetSRID(ST_MakeEnvelope(${minlon}, ${minlat}, ${maxlon}, ${maxlat}), 4326)),
-              3857
-            )
-          `.replaceAll('"', '\\"')
-          const outputFilePath = path.resolve(
-            'public',
-            'temp',
-            `export-temp-${Date.now()}.${format}`,
-          )
-          const dbConnection = `PG:"${getBaseDatabaseUrl()}"`
-          const layerName = regionSlug && regionSlug !== 'noRegion' ? regionSlug : undefined
-
-          const isGdalAvailable = await checkGdalVersion()
-
-          const ogrFormat = ogrFormats[format]
-          // Export output is WGS84 (GeoJSON RFC 7946; public API contract)
-          const ogrCommand = `ogr2ogr \
-            -f "${ogrFormat.driver}" \
-            -t_srs EPSG:4326 \
-            -lco COORDINATE_PRECISION=8 \
-            -sql "${sqlQuery}" \
-            ${layerName ? `-nln ${layerName}` : ''} \
-            "${outputFilePath}" \
-            ${dbConnection}`
-
-          const ogrStartedAt = Date.now()
-          let ogrDurationMs = 0
-          await new Promise<void>((resolve, reject) => {
-            exec(ogrCommand, { maxBuffer: 1024 * 1024 * 50 }, (error, stdout, stderr) => {
-              ogrDurationMs = Date.now() - ogrStartedAt
-              if (error) {
-                console.error(logPrefix, 'ogr2ogr failed', {
-                  ogrDurationMs,
-                  errorMessage: error.message,
-                  stderrPreview: stderr ? stderr.slice(0, 4000) : undefined,
-                  stdoutPreview: stdout ? stdout.slice(0, 2000) : undefined,
-                })
-                reject(error)
-                return
-              }
-              if (stderr && isDev) {
-                console.warn('[EXPORT] ogr2ogr stderr:', stderr)
-              }
-              if (stdout && isDev) {
-                console.info('[EXPORT] ogr2ogr stdout:', stdout)
-              }
-              resolve()
-            })
+          const { outputFilePath, outputBytes, mimeType } = await generateExport({
+            tableName,
+            regionSlug,
+            format,
+            bbox,
+            logPrefix,
           })
-
-          let metadataEditDurationMs = 0
-          if (isGdalAvailable) {
-            const exportExt = path.extname(outputFilePath)
-            const exportBase = path.basename(outputFilePath, exportExt)
-            const exportDir = path.dirname(outputFilePath)
-            // FlatGeobuf treats paths like "*.fgb.<non-ext>" as directory outputs; keep real suffix.
-            const tempMetadataPath = path.join(exportDir, `${exportBase}.gdal-meta${exportExt}`)
-            const metadataArgs = Object.entries(exportMetadata).flatMap(([key, value]) => [
-              '--metadata',
-              `${key}=${value}`,
-            ])
-
-            const gdalMetadataStartedAt = Date.now()
-            await new Promise<void>((resolve) => {
-              execFile(
-                'gdal',
-                [
-                  'vector',
-                  'edit',
-                  '-i',
-                  outputFilePath,
-                  '-o',
-                  tempMetadataPath,
-                  '-f',
-                  ogrFormat.driver,
-                  ...metadataArgs,
-                ],
-                { maxBuffer: 1024 * 1024 * 50 },
-                (error) => {
-                  void (async () => {
-                    try {
-                      if (error) {
-                        console.warn(logPrefix, 'gdal metadata update failed', {
-                          errorMessage: error.message,
-                          metadataEditDurationMs: Date.now() - gdalMetadataStartedAt,
-                        })
-                        await unlinkExportFile(tempMetadataPath, logPrefix, 'gdal_metadata_failed')
-                      } else {
-                        await fs.unlink(outputFilePath)
-                        await fs.rename(tempMetadataPath, outputFilePath)
-                        metadataEditDurationMs = Date.now() - gdalMetadataStartedAt
-                      }
-                    } catch (replaceError) {
-                      console.warn(logPrefix, 'gdal metadata replace failed', {
-                        replaceError,
-                        metadataEditDurationMs: Date.now() - gdalMetadataStartedAt,
-                      })
-                      await unlinkExportFile(
-                        tempMetadataPath,
-                        logPrefix,
-                        'gdal_metadata_replace_failed',
-                      )
-                    } finally {
-                      resolve()
-                    }
-                  })()
-                },
-              )
-            })
-          }
-
-          const outputStats = await fs.stat(outputFilePath)
-          console.info(logPrefix, 'prepared export', {
-            outputFilePath,
-            outputBytes: outputStats.size,
-            tagKeysCount: tagKeyQuery.length,
-            metaKeysCount: metaKeyQuery.length,
-            hasOsmId,
-            hasOsmType,
-            columnsMetadataTimingsMs,
-            ogrDurationMs,
-            metadataEditDurationMs,
-            totalDurationMs: Date.now() - requestStartedAt,
-          })
-
-          const metadata = await getProcessingMeta()
-          const filename = metadata.osm_data_from
-            ? `${tableName}_${formatDateBerlin(metadata.osm_data_from, 'yyyy-MM-dd')}.${format}`
-            : `${tableName}.${format}`
+          const filename = await buildExportFilename(tableName, format)
 
           console.info(logPrefix, 'starting response stream', {
             filename,
-            mimeType: ogrFormat.mimeType,
-            contentLength: outputStats.size,
+            mimeType,
+            contentLength: outputBytes,
             totalDurationMs: Date.now() - requestStartedAt,
           })
 
           return new Response(
-            createExportFileResponseStream({
-              outputFilePath,
-              logPrefix,
-              requestStartedAt,
-            }),
+            createExportFileResponseStream({ outputFilePath, logPrefix, requestStartedAt }),
             {
               headers: {
                 ...corsHeaders,
-                'Content-Type': ogrFormat.mimeType,
-                'Content-Length': outputStats.size.toString(),
+                'Content-Type': mimeType,
+                'Content-Length': outputBytes.toString(),
                 'Content-Disposition': `attachment; filename="${filename}"`,
               },
             },
           )
         } catch (error) {
           console.error(logPrefix, 'export failed', {
-            regionSlug: params.regionSlug,
-            tableName: params.tableName,
+            regionSlug,
+            tableName,
             requestUrl: request.url,
             totalDurationMs: Date.now() - requestStartedAt,
             error,

--- a/app/src/server/api/export/exportJobs.server.ts
+++ b/app/src/server/api/export/exportJobs.server.ts
@@ -1,0 +1,80 @@
+import { unlinkExportFile } from '@/server/api/export/streamExportFile.server'
+
+export type ExportJobStatus = 'running' | 'done' | 'error'
+
+export type ExportJob = {
+  id: string
+  status: ExportJobStatus
+  percent: number
+  filename: string
+  outputFilePath?: string
+  outputBytes?: number
+  mimeType?: string
+  error?: string
+  createdAt: number
+  updatedAt: number
+}
+
+// Jobs live in-memory in the single app container. Stored on globalThis so dev HMR
+// (which re-evaluates modules) does not drop running jobs or spawn duplicate sweepers.
+const globalForJobs = globalThis as typeof globalThis & {
+  __tildaExportJobs?: Map<string, ExportJob>
+  __tildaExportJobsSweeper?: NodeJS.Timeout
+}
+
+const jobs = (globalForJobs.__tildaExportJobs ??= new Map<string, ExportJob>())
+
+const JOB_TTL_MS = 30 * 60 * 1000
+const SWEEP_INTERVAL_MS = 5 * 60 * 1000
+
+const createJobId = () => `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`
+
+export function createExportJob(filename: string): ExportJob {
+  const now = Date.now()
+  const job: ExportJob = {
+    id: createJobId(),
+    status: 'running',
+    percent: 0,
+    filename,
+    createdAt: now,
+    updatedAt: now,
+  }
+  jobs.set(job.id, job)
+  return job
+}
+
+export function getExportJob(id: string): ExportJob | undefined {
+  return jobs.get(id)
+}
+
+export function updateExportJob(id: string, patch: Partial<Omit<ExportJob, 'id'>>): void {
+  const job = jobs.get(id)
+  if (!job) return
+  Object.assign(job, patch, { updatedAt: Date.now() })
+}
+
+/** Removes the job from the registry and deletes its temp file if still present. */
+export function removeExportJob(id: string): void {
+  const job = jobs.get(id)
+  if (!job) return
+  jobs.delete(id)
+  if (job.outputFilePath) {
+    void unlinkExportFile(job.outputFilePath, `[EXPORT-JOB:${id}]`, 'job_removed')
+  }
+}
+
+// Drop abandoned jobs (e.g. user closed the tab before downloading) and their temp files.
+function sweepExpiredJobs() {
+  const now = Date.now()
+  for (const [id, job] of jobs) {
+    if (now - job.updatedAt > JOB_TTL_MS) {
+      removeExportJob(id)
+    }
+  }
+}
+
+if (!globalForJobs.__tildaExportJobsSweeper) {
+  globalForJobs.__tildaExportJobsSweeper = setInterval(sweepExpiredJobs, SWEEP_INTERVAL_MS)
+  // Do not keep the process alive just for the sweeper.
+  globalForJobs.__tildaExportJobsSweeper.unref?.()
+}

--- a/app/src/server/api/export/exportRequest.server.ts
+++ b/app/src/server/api/export/exportRequest.server.ts
@@ -1,0 +1,38 @@
+import { z } from 'zod'
+import { exportApiIdentifier } from '@/components/regionen/pageRegionSlug/mapData/mapDataSources/export/exportIdentifier'
+import { formatDateBerlin } from '@/components/shared/date/formatDateBerlin'
+import { formats } from '@/server/api/export/ogrFormats.const'
+import { getProcessingMeta } from '@/server/api/util/getProcessingMeta.server'
+
+export const exportParamsSchema = z.object({
+  regionSlug: z.string(),
+  tableName: z.enum(exportApiIdentifier),
+})
+
+export const exportSearchSchema = z.object({
+  apiKey: z.string().optional(),
+  minlon: z.coerce.number(),
+  minlat: z.coerce.number(),
+  maxlon: z.coerce.number(),
+  maxlat: z.coerce.number(),
+  format: z.enum(formats),
+})
+
+export function parseExportSearch(rawSearchParams: URLSearchParams) {
+  return exportSearchSchema.safeParse({
+    apiKey: rawSearchParams.get('apiKey') || '',
+    minlon: rawSearchParams.get('minlon'),
+    minlat: rawSearchParams.get('minlat'),
+    maxlon: rawSearchParams.get('maxlon'),
+    maxlat: rawSearchParams.get('maxlat'),
+    format: rawSearchParams.get('format') || 'fgb',
+  })
+}
+
+/** `<tableName>_<osm-date>.<format>`, falling back to `<tableName>.<format>`. */
+export async function buildExportFilename(tableName: string, format: string) {
+  const metadata = await getProcessingMeta()
+  return metadata.osm_data_from
+    ? `${tableName}_${formatDateBerlin(metadata.osm_data_from, 'yyyy-MM-dd')}.${format}`
+    : `${tableName}.${format}`
+}

--- a/app/src/server/api/export/generateExport.server.ts
+++ b/app/src/server/api/export/generateExport.server.ts
@@ -1,0 +1,175 @@
+import { spawn } from 'node:child_process'
+import fs from 'node:fs/promises'
+import path from 'node:path'
+import { getExportAttributeType } from '@/server/api/export/exportAttributeType'
+import { type Formats, ogrFormats } from '@/server/api/export/ogrFormats.const'
+import { getBaseDatabaseUrl } from '@/server/database-url.server'
+import { geoDataClient } from '@/server/prisma-client.server'
+
+// Embedded into the output layer via ogr2ogr `-mo` (replaces the former, slow
+// post-processing pass that rewrote the whole file just to add these fields).
+const exportMetadata = {
+  licence: 'ODbL',
+  attribution: '(c) OpenStreetMap; tilda-geo.de',
+  owner: 'FixMyCity GmbH / TILDA Geo',
+}
+
+export type GenerateExportInput = {
+  tableName: string
+  regionSlug: string
+  format: Formats
+  bbox: { minlon: number; minlat: number; maxlon: number; maxlat: number }
+  logPrefix: string
+  /** Called with 0..100 as ogr2ogr reports progress. */
+  onProgress?: (percent: number) => void
+}
+
+export type GenerateExportResult = {
+  outputFilePath: string
+  outputBytes: number
+  mimeType: string
+}
+
+const sanitizeKey = (key: string) => key.replace(/[^a-z]/gi, '_')
+
+/**
+ * Builds the export file on disk via ogr2ogr and resolves once the file is ready.
+ * Reports progress in real time by parsing ogr2ogr's `-progress` output (`0...10...100`).
+ */
+export async function generateExport({
+  tableName,
+  regionSlug,
+  format,
+  bbox,
+  logPrefix,
+  onProgress,
+}: GenerateExportInput): Promise<GenerateExportResult> {
+  const { minlon, minlat, maxlon, maxlat } = bbox
+
+  // Discover the columns to export from the table's `tags`/`meta` jsonb keys.
+  const tagKeyQuery: Array<{ key: string }> = await geoDataClient.$queryRawUnsafe(`
+      SELECT DISTINCT jsonb_object_keys(tags) AS key
+      FROM "${tableName}"
+    `)
+  const metaKeyQuery: Array<{ key: string }> = await geoDataClient.$queryRawUnsafe(`
+      SELECT DISTINCT jsonb_object_keys(meta) AS key
+      FROM "${tableName}"
+    `)
+  const columnExistsQuery: Array<{ column_name: string }> = await geoDataClient.$queryRawUnsafe(`
+      SELECT column_name
+      FROM information_schema.columns
+      WHERE table_name = '${tableName}'
+      AND column_name IN ('osm_id', 'osm_type')
+    `)
+  const existingColumns = columnExistsQuery.map(({ column_name }) => column_name)
+  const hasOsmId = existingColumns.includes('osm_id')
+  const hasOsmType = existingColumns.includes('osm_type')
+
+  const generateColumn = (key: string, columnType: 'tags' | 'meta') => {
+    const attributeType = getExportAttributeType(key)
+    const sanitizedKey = sanitizeKey(key)
+    return attributeType === 'number'
+      ? `CAST(${columnType}->>'${key}' AS numeric) AS "${sanitizedKey}"`
+      : `${columnType}->>'${key}' AS "${sanitizedKey}"`
+  }
+
+  const columns = [
+    'id',
+    'geom',
+    hasOsmId ? 'osm_id' : undefined,
+    hasOsmType ? 'osm_type' : undefined,
+    ...tagKeyQuery.map(({ key }) => generateColumn(key, 'tags')),
+    ...metaKeyQuery.map(({ key }) => generateColumn(key, 'meta')),
+  ]
+    .filter(Boolean)
+    .join(',\n')
+
+  // Passed verbatim to ogr2ogr via spawn (no shell), so identifier quotes need no escaping.
+  const sqlQuery = `
+    SELECT ${columns}
+    FROM public."${tableName}"
+    WHERE geom && ST_Transform(
+      (SELECT ST_SetSRID(ST_MakeEnvelope(${minlon}, ${minlat}, ${maxlon}, ${maxlat}), 4326)),
+      3857
+    )
+  `
+
+  const ogrFormat = ogrFormats[format]
+  const outputDir = path.resolve('public', 'temp')
+  await fs.mkdir(outputDir, { recursive: true })
+  const outputFilePath = path.join(outputDir, `export-temp-${Date.now()}.${format}`)
+  const layerName = regionSlug && regionSlug !== 'noRegion' ? regionSlug : undefined
+
+  const metadataArgs = Object.entries(exportMetadata).flatMap(([key, value]) => [
+    '-mo',
+    `${key}=${value}`,
+  ])
+
+  // Export output is WGS84 (GeoJSON RFC 7946; public API contract).
+  const ogrArgs = [
+    '-f',
+    ogrFormat.driver,
+    '-t_srs',
+    'EPSG:4326',
+    '-lco',
+    'COORDINATE_PRECISION=8',
+    '-progress',
+    ...metadataArgs,
+    '-sql',
+    sqlQuery,
+    ...(layerName ? ['-nln', layerName] : []),
+    outputFilePath,
+    `PG:${getBaseDatabaseUrl()}`,
+  ]
+
+  const ogrStartedAt = Date.now()
+  await new Promise<void>((resolve, reject) => {
+    const child = spawn('ogr2ogr', ogrArgs)
+    let lastPercent = 0
+    let stderr = ''
+
+    // ogr2ogr `-progress` writes `0...10...20...100 - done.` to stdout incrementally.
+    child.stdout.on('data', (chunk: Buffer) => {
+      const matches = chunk.toString().match(/\d+/g)
+      if (!matches) return
+      const percent = Math.min(100, Math.max(...matches.map(Number)))
+      if (percent > lastPercent) {
+        lastPercent = percent
+        onProgress?.(percent)
+      }
+    })
+    child.stderr.on('data', (chunk: Buffer) => {
+      stderr += chunk.toString()
+    })
+    child.on('error', (error) => reject(error))
+    child.on('close', (code) => {
+      if (code === 0) {
+        resolve()
+        return
+      }
+      console.error(logPrefix, 'ogr2ogr failed', {
+        code,
+        ogrDurationMs: Date.now() - ogrStartedAt,
+        stderrPreview: stderr.slice(0, 4000),
+      })
+      reject(new Error(`ogr2ogr exited with code ${code}: ${stderr.slice(0, 500)}`))
+    })
+  })
+
+  const outputStats = await fs.stat(outputFilePath)
+  console.info(logPrefix, 'prepared export', {
+    outputFilePath,
+    outputBytes: outputStats.size,
+    tagKeysCount: tagKeyQuery.length,
+    metaKeysCount: metaKeyQuery.length,
+    hasOsmId,
+    hasOsmType,
+    ogrDurationMs: Date.now() - ogrStartedAt,
+  })
+
+  return {
+    outputFilePath,
+    outputBytes: outputStats.size,
+    mimeType: ogrFormat.mimeType,
+  }
+}

--- a/app/src/server/api/export/streamExportFile.server.ts
+++ b/app/src/server/api/export/streamExportFile.server.ts
@@ -1,0 +1,75 @@
+import { createReadStream } from 'node:fs'
+import fs from 'node:fs/promises'
+
+export async function unlinkExportFile(outputFilePath: string, logPrefix: string, reason: string) {
+  try {
+    await fs.unlink(outputFilePath)
+  } catch (unlinkError) {
+    console.warn(logPrefix, 'failed to remove temp export file', {
+      outputFilePath,
+      reason,
+      unlinkError,
+    })
+  }
+}
+
+/**
+ * Streams a finished export file to the client and removes the temp file once the
+ * response is done (completed, failed or canceled). `onFinalized` runs after cleanup
+ * so callers can drop additional state (e.g. a job registry entry).
+ */
+export function createExportFileResponseStream({
+  outputFilePath,
+  logPrefix,
+  requestStartedAt,
+  onFinalized,
+}: {
+  outputFilePath: string
+  logPrefix: string
+  requestStartedAt: number
+  onFinalized?: (reason: string) => void
+}) {
+  const nodeStream = createReadStream(outputFilePath)
+  let bytesStreamed = 0
+  let didCleanup = false
+  const cleanupFile = (reason: string) => {
+    if (didCleanup) return
+    didCleanup = true
+    void unlinkExportFile(outputFilePath, logPrefix, reason).finally(() => onFinalized?.(reason))
+  }
+
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      nodeStream.on('data', (chunk: Buffer) => {
+        bytesStreamed += chunk.length
+        controller.enqueue(new Uint8Array(chunk))
+      })
+      nodeStream.on('end', () => {
+        controller.close()
+        console.info(logPrefix, 'stream completed', {
+          bytesStreamed,
+          totalDurationMs: Date.now() - requestStartedAt,
+        })
+        cleanupFile('stream_completed')
+      })
+      nodeStream.on('error', (streamError) => {
+        console.error(logPrefix, 'stream failed', {
+          bytesStreamed,
+          totalDurationMs: Date.now() - requestStartedAt,
+          streamError,
+        })
+        controller.error(streamError)
+        cleanupFile('stream_failed')
+      })
+    },
+    cancel(cancelReason) {
+      nodeStream.destroy()
+      console.warn(logPrefix, 'stream canceled by client', {
+        bytesStreamed,
+        totalDurationMs: Date.now() - requestStartedAt,
+        cancelReason,
+      })
+      cleanupFile('stream_canceled')
+    },
+  })
+}


### PR DESCRIPTION
## Problem

Large exports (z.B. Deutschland-weit) schlagen fehl – der Server erzeugt die Datei, aber die HTTP-Verbindung läuft vorher in einen Timeout (FixMyBerlin/private-issues#3218).

## Lösung

Synchrones Streaming durch einen dreistufigen Async-Job-Flow ersetzt:

1. **`GET /api/export-start/:region/:table`** – startet Export im Hintergrund, gibt `jobId` zurück
2. **`GET /api/export-status/:jobId`** – Client pollt Fortschritt (Prozentanzeige möglich)
3. **`GET /api/export-download/:jobId`** – streamt fertige Datei, löscht danach Temp-Datei + Job

Der Client (Download-Modal) wurde entsprechend angepasst.

## Geänderte Dateien

Weitere Relevante Änderung: Metadaten werden nun in ogr2ogr geschrieben -> Wie überprüfen, dass vorhanden ist?

| Bereich | Änderung |
|---|---|
| `export-start.$regionSlug.$tableName.ts` | Neu: Job starten |
| `export-status.$jobId.ts` | Neu: Status pollen |
| `export-download.$jobId.ts` | Neu: Datei streamen |
| `exportJobs.server.ts` | Neu: In-memory Job-Store |
| `exportRequest.server.ts` | Neu: Shared params / filename logic |
| `generateExport.server.ts` | Neu: OGR-Aufruf ausgelagert |
| `streamExportFile.server.ts` | Neu: File-Stream-Helper |
| `OgrFormatDownloadLinks.tsx` | Angepasst: polling UI |
| `export.$regionSlug.$tableName.ts` | Bereinigt: alter sync-Handler entfernt |

## Test

```
GET /api/export-start/deutschland/bikelanes?minlon=5.8663153&minlat=47.2701114&maxlon=15.0419309&maxlat=55.099161&format=fgb
```

Refs: FixMyBerlin/private-issues#3218

🤖 Generated with [Claude Code](https://claude.com/claude-code)