### PR TITLE
Processing: derive width from width/est_width with confidence

### DIFF
--- a/app/src/data/generated/topicDocs/byTableName.gen.ts
+++ b/app/src/data/generated/topicDocs/byTableName.gen.ts
@@ -1213,6 +1213,25 @@ const data = {
         ],
       },
       {
+        key: 'width_confidence',
+        type: 'string',
+        label: 'Konfidenz Breite',
+        purpose: 'qa',
+        values: [
+          {
+            value: 'high',
+            label: 'Direkt gemessen',
+            description: 'Wert stammt aus dem OSM-Tag `width`.',
+          },
+          {
+            value: 'low',
+            label: 'Geschätzt',
+            description:
+              'Wert stammt aus dem OSM-Tag `est_width`, weil `width` fehlt oder nicht geparst werden konnte.',
+          },
+        ],
+      },
+      {
         key: 'oneway',
         type: 'string',
         label: 'Verkehrsrichtung',
@@ -9939,6 +9958,25 @@ const data = {
         ],
       },
       {
+        key: 'width_confidence',
+        type: 'string',
+        label: 'Konfidenz Breite',
+        purpose: 'qa',
+        values: [
+          {
+            value: 'high',
+            label: 'Direkt gemessen',
+            description: 'Wert stammt aus dem OSM-Tag `width`.',
+          },
+          {
+            value: 'low',
+            label: 'Geschätzt',
+            description:
+              'Wert stammt aus dem OSM-Tag `est_width`, weil `width` fehlt oder nicht geparst werden konnte.',
+          },
+        ],
+      },
+      {
         key: 'oneway',
         type: 'string',
         label: 'Verkehrsrichtung',
@@ -11294,6 +11332,25 @@ const data = {
           {
             value: 'ARCore',
             label: 'Mit dem Handy-Metermaß von StreetComplete gemessen',
+          },
+        ],
+      },
+      {
+        key: 'width_confidence',
+        type: 'string',
+        label: 'Konfidenz Breite',
+        purpose: 'qa',
+        values: [
+          {
+            value: 'high',
+            label: 'Direkt gemessen',
+            description: 'Wert stammt aus dem OSM-Tag `width`.',
+          },
+          {
+            value: 'low',
+            label: 'Geschätzt',
+            description:
+              'Wert stammt aus dem OSM-Tag `est_width`, weil `width` fehlt oder nicht geparst werden konnte.',
           },
         ],
       },

--- a/app/src/data/generated/topicDocs/inspectorDescriptions.gen.ts
+++ b/app/src/data/generated/topicDocs/inspectorDescriptions.gen.ts
@@ -26,6 +26,10 @@ const data = {
         'Seitlicher Versatz der Liniengeometrie in Metern. Der Wert wird im Processing aus der halben Straßenbreite berechnet; positive Werte liegen links der Referenzlinie, negative rechts.',
     },
     values: {
+      width_confidence: {
+        high: 'Wert stammt aus dem OSM-Tag `width`.',
+        low: 'Wert stammt aus dem OSM-Tag `est_width`, weil `width` fehlt oder nicht geparst werden konnte.',
+      },
       oneway: {
         assumed_no:
           'Keine explizite OSM-Angabe zur Verkehrsrichtung vorhanden. Aus Führungsform und Umfeld wird hier beide Richtungen als wahrscheinlich angenommen.',
@@ -108,7 +112,12 @@ const data = {
       mapillary_traffic_sign:
         'Mapillary-Bild-IDs für Verkehrszeichen (technisch bereinigt). Mehrere IDs sind als semikolongetrennte Liste möglich. Im Inspector wird pro ID ein Link erzeugt, z. B. `https://www.mapillary.com/app/?pKey=<ID>&focus=photo&z=15`.',
     },
-    values: {},
+    values: {
+      width_confidence: {
+        high: 'Wert stammt aus dem OSM-Tag `width`.',
+        low: 'Wert stammt aus dem OSM-Tag `est_width`, weil `width` fehlt oder nicht geparst werden konnte.',
+      },
+    },
   },
   atlas_roadsPathClasses: {
     keys: {
@@ -125,7 +134,12 @@ const data = {
       mapillary_traffic_sign:
         'Mapillary-Bild-IDs für Verkehrszeichen (technisch bereinigt). Mehrere IDs sind als semikolongetrennte Liste möglich. Im Inspector wird pro ID ein Link erzeugt, z. B. `https://www.mapillary.com/app/?pKey=<ID>&focus=photo&z=15`.',
     },
-    values: {},
+    values: {
+      width_confidence: {
+        high: 'Wert stammt aus dem OSM-Tag `width`.',
+        low: 'Wert stammt aus dem OSM-Tag `est_width`, weil `width` fehlt oder nicht geparst werden konnte.',
+      },
+    },
   },
   atlas_trafficSigns: {
     keys: {

--- a/app/src/data/generated/topicDocs/inspectorTranslations.gen.ts
+++ b/app/src/data/generated/topicDocs/inspectorTranslations.gen.ts
@@ -462,6 +462,12 @@ const data = {
   'atlas_bikelanes--traffic_sign=none': 'Unbeschildert',
   'atlas_bikelanes--tunnel--key': 'Tunnel',
   'atlas_bikelanes--tunnel=yes': 'Ja',
+  'atlas_bikelanes--width_confidence--key': 'Konfidenz Breite',
+  'atlas_bikelanes--width_confidence=high': 'Direkt gemessen',
+  'atlas_bikelanes--width_confidence=high--description': 'Wert stammt aus dem OSM-Tag `width`.',
+  'atlas_bikelanes--width_confidence=low': 'Geschätzt',
+  'atlas_bikelanes--width_confidence=low--description':
+    'Wert stammt aus dem OSM-Tag `est_width`, weil `width` fehlt oder nicht geparst werden konnte.',
   'atlas_bikelanes--width_effective--key': 'Effektive Breite',
   'atlas_bikelanes--width_source--key': 'Quelle Breite',
   'atlas_bikelanes--width_source=ALKIS': 'Aus ALKIS Daten ausgemessen',
@@ -1444,6 +1450,12 @@ const data = {
   'atlas_roads--traffic_sign=none': 'Unbeschildert',
   'atlas_roads--tunnel--key': 'Tunnel',
   'atlas_roads--tunnel=yes': 'Ja',
+  'atlas_roads--width_confidence--key': 'Konfidenz Breite',
+  'atlas_roads--width_confidence=high': 'Direkt gemessen',
+  'atlas_roads--width_confidence=high--description': 'Wert stammt aus dem OSM-Tag `width`.',
+  'atlas_roads--width_confidence=low': 'Geschätzt',
+  'atlas_roads--width_confidence=low--description':
+    'Wert stammt aus dem OSM-Tag `est_width`, weil `width` fehlt oder nicht geparst werden konnte.',
   'atlas_roads--width_effective--key': 'Effektive Breite',
   'atlas_roads--width_source--key': 'Quelle Breite',
   'atlas_roads--width_source=ALKIS': 'Aus ALKIS Daten ausgemessen',
@@ -1733,6 +1745,13 @@ const data = {
   'atlas_roadsPathClasses--todos--key': 'Todo-Liste',
   'atlas_roadsPathClasses--traffic_sign--key': 'Beschilderung',
   'atlas_roadsPathClasses--traffic_sign=none': 'Unbeschildert',
+  'atlas_roadsPathClasses--width_confidence--key': 'Konfidenz Breite',
+  'atlas_roadsPathClasses--width_confidence=high': 'Direkt gemessen',
+  'atlas_roadsPathClasses--width_confidence=high--description':
+    'Wert stammt aus dem OSM-Tag `width`.',
+  'atlas_roadsPathClasses--width_confidence=low': 'Geschätzt',
+  'atlas_roadsPathClasses--width_confidence=low--description':
+    'Wert stammt aus dem OSM-Tag `est_width`, weil `width` fehlt oder nicht geparst werden konnte.',
   'atlas_roadsPathClasses--width_source--key': 'Quelle Breite',
   'atlas_roadsPathClasses--width_source=ALKIS': 'Aus ALKIS Daten ausgemessen',
   'atlas_roadsPathClasses--width_source=ARCore':

--- a/app/src/data/generated/topicDocs/masterportalByTableName.gen.ts
+++ b/app/src/data/generated/topicDocs/masterportalByTableName.gen.ts
@@ -467,6 +467,15 @@ const data = {
           ARCore: 'Mit dem Handy-Metermaß von StreetComplete gemessen',
         },
       },
+      width_confidence: {
+        name: 'Konfidenz Breite',
+        condition: 'contains',
+        type: 'string',
+        format: {
+          high: 'Direkt gemessen',
+          low: 'Geschätzt',
+        },
+      },
       oneway: {
         name: 'Verkehrsrichtung',
         condition: 'contains',
@@ -3621,6 +3630,15 @@ const data = {
           ARCore: 'Mit dem Handy-Metermaß von StreetComplete gemessen',
         },
       },
+      width_confidence: {
+        name: 'Konfidenz Breite',
+        condition: 'contains',
+        type: 'string',
+        format: {
+          high: 'Direkt gemessen',
+          low: 'Geschätzt',
+        },
+      },
       oneway: {
         name: 'Verkehrsrichtung',
         condition: 'contains',
@@ -4239,6 +4257,15 @@ const data = {
         format: {
           ALKIS: 'Aus ALKIS Daten ausgemessen',
           ARCore: 'Mit dem Handy-Metermaß von StreetComplete gemessen',
+        },
+      },
+      width_confidence: {
+        name: 'Konfidenz Breite',
+        condition: 'contains',
+        type: 'string',
+        format: {
+          high: 'Direkt gemessen',
+          low: 'Geschätzt',
         },
       },
       surface: {

--- a/processing/topics/helper/__tests__/derive_width.test.lua
+++ b/processing/topics/helper/__tests__/derive_width.test.lua
@@ -1,0 +1,80 @@
+describe('derive_width', function()
+  require('topics.helper.osm2pgsql')
+  local derive_width = require('topics.helper.derive_width')
+
+  describe('with width tag', function()
+    it('returns high confidence and keeps source:width', function()
+      local result = derive_width({
+        width = '3.5 m',
+        ['source:width'] = 'Handy-Ausmessen',
+      })
+      assert.are.same(result, {
+        width = 3.5,
+        width_source = 'Handy-Ausmessen',
+        width_confidence = 'high',
+      })
+    end)
+
+    it('prefers width over est_width', function()
+      local result = derive_width({
+        width = '4 m',
+        est_width = '6 m',
+      })
+      assert.are.same(result, {
+        width = 4,
+        width_source = nil,
+        width_confidence = 'high',
+      })
+    end)
+  end)
+
+  describe('with est_width fallback', function()
+    it('returns low confidence when width is missing', function()
+      local result = derive_width({
+        est_width = '6m',
+        ['source:width'] = 'estimation',
+      })
+      assert.are.same(result, {
+        width = 6,
+        width_source = 'estimation',
+        width_confidence = 'low',
+      })
+    end)
+
+    it('falls back to est_width when width is unparsable', function()
+      local result = derive_width({
+        width = 'fehlerhafter Text',
+        est_width = '5',
+      })
+      assert.are.same(result, {
+        width = 5,
+        width_source = nil,
+        width_confidence = 'low',
+      })
+    end)
+  end)
+
+  describe('with no usable width', function()
+    it('returns nils when both tags are missing', function()
+      local result = derive_width({})
+      assert.are.same(result, {
+        width = nil,
+        width_source = nil,
+        width_confidence = nil,
+      })
+    end)
+
+    it('returns nils when both tags are unparsable', function()
+      local result = derive_width({
+        width = 'invalid_width',
+        est_width = 'invalid_est_width',
+        ['source:width'] = 'ALKIS',
+      })
+      assert.are.same(result, {
+        width = nil,
+        width_source = nil,
+        width_confidence = nil,
+      })
+    end)
+  end)
+end)

--- a/processing/topics/helper/derive_width.lua
+++ b/processing/topics/helper/derive_width.lua
@@ -1,0 +1,57 @@
+local parse_length = require('topics.helper.parse_length')
+local SANITIZE_TAGS = require('topics.helper.sanitize_tags')
+
+---@alias DeriveWidthConfidence 'high'|'low'
+---@class DeriveWidthResultEmpty
+---@field width nil
+---@field width_source nil
+---@field width_confidence nil
+---@class DeriveWidthResult
+---@field width number
+---@field width_source string|nil
+---@field width_confidence DeriveWidthConfidence
+---@alias DeriveWidthResultUnion DeriveWidthResultEmpty|DeriveWidthResult
+
+---@param tags OsmTags
+---@return DeriveWidthResultUnion
+local function width_direct(tags)
+  local width = parse_length(tags.width)
+  if width then
+    return {
+      width = width,
+      width_source = SANITIZE_TAGS.safe_string(tags['source:width']),
+      width_confidence = 'high',
+    }
+  end
+
+  return { width = nil, width_source = nil, width_confidence = nil, }
+end
+
+---@param tags OsmTags
+---@return DeriveWidthResultUnion
+local function width_estimated(tags)
+  local width = parse_length(tags.est_width)
+  if width then
+    return {
+      width = width,
+      width_source = SANITIZE_TAGS.safe_string(tags['source:width']),
+      width_confidence = 'low',
+    }
+  end
+
+  return { width = nil, width_source = nil, width_confidence = nil, }
+end
+
+---Derive road width from OSM `width` or fallback `est_width`, plus confidence and OSM `source:width`.
+---@param tags OsmTags
+---@return DeriveWidthResultUnion
+local function derive_width(tags)
+  local direct = width_direct(tags)
+  if direct.width then
+    return direct
+  end
+
+  return width_estimated(tags)
+end
+
+return derive_width

--- a/processing/topics/helper/exclude_by_width.lua
+++ b/processing/topics/helper/exclude_by_width.lua
@@ -1,7 +1,11 @@
+local parse_length = require('topics.helper.parse_length')
+
 -- * @desc If and why a highway object should be excluded based on its width.
+-- * @param tags OsmTags
+-- * @param min_width number
 -- * @returns { boolean (shouldFilter), string (reason) }
 function exclude_by_width(tags, min_width)
-  local width = tonumber(tags.width)
+  local width = parse_length(tags.width)
   if width and width < min_width then
     return true, ';Excluded since `width<' .. min_width .. '` indicates a special interest path'
   end

--- a/processing/topics/roads_bikelanes/bikelanes/__tests__/bikelanes.test.lua
+++ b/processing/topics/roads_bikelanes/bikelanes/__tests__/bikelanes.test.lua
@@ -79,11 +79,28 @@ describe('bikelanes', function()
       assert.are.equal(result[1].width, 5)
     end)
 
+    it('handles est_width alone with low width_confidence', function()
+      local input_object = {
+        tags = {
+          highway = 'path',
+          bicycle = 'designated',
+          foot = 'designated',
+          est_width = '2.5',
+        },
+        id = 1,
+        type = 'way'
+      }
+      local result = run_bikelanes(input_object)
+      assert.are.equal(result[1].width, 2.5)
+      assert.are.equal(result[1].width_confidence, 'low')
+    end)
+
     it('handles source:cycleway:left:width for width_source', function()
       local input_object = {
         tags = {
           highway = 'primary',
           ['cycleway:left'] = 'lane',
+          ['cycleway:left:width'] = '2 m',
           ['source:cycleway:left:width'] = 'infra3D',
         },
         id = 1,
@@ -100,6 +117,7 @@ describe('bikelanes', function()
           highway = 'primary',
           ['sidewalk:left'] = 'yes',
           ['sidewalk:left:bicycle'] = 'yes',
+          ['sidewalk:both:width'] = '2 m',
           ['source:sidewalk:both:width'] = 'infra3D',
         },
         id = 1,
@@ -115,6 +133,7 @@ describe('bikelanes', function()
         tags = {
           highway = 'primary',
           ['cycleway:left'] = 'lane',
+          ['cycleway:width'] = '2 m',
           ['source:cycleway:width'] = 'infra3D',
         },
         id = 1,
@@ -131,6 +150,7 @@ describe('bikelanes', function()
           highway = 'path',
           ['bicycle'] = 'designated',
           ['foot'] = 'designated',
+          ['cycleway:width'] = '2 m',
           ['source:cycleway:width'] = 'infra3D',
         },
         id = 1,
@@ -147,6 +167,7 @@ describe('bikelanes', function()
           highway = 'primary',
           ['sidewalk:left'] = 'yes',
           ['sidewalk:left:bicycle'] = 'yes',
+          ['cycleway:width'] = '2 m',
           ['source:cycleway:width'] = 'infra3D',
         },
         id = 1,
@@ -162,6 +183,7 @@ describe('bikelanes', function()
         tags = {
           highway = 'footway',
           ['bicycle'] = 'yes',
+          ['cycleway:width'] = '2 m',
           ['source:cycleway:width'] = 'infra3D',
         },
         id = 1,

--- a/processing/topics/roads_bikelanes/bikelanes/extract_bikelanes.lua
+++ b/processing/topics/roads_bikelanes/bikelanes/extract_bikelanes.lua
@@ -4,6 +4,7 @@ local transformations = require('topics.roads_bikelanes.bikelanes.transformation
 local merge_table = require('topics.helper.merge_table')
 local road_width = require('topics.helper.road_width')
 local derive_surface = require('topics.helper.derive_surface')
+local derive_width = require('topics.helper.derive_width')
 local derive_smoothness = require('topics.helper.derive_smoothness')
 local bikelane_todo_categories = require('topics.roads_bikelanes.bikelanes.bikelane_todo_categories')
 local collect_todos = require('topics.helper.collect_todos')
@@ -88,8 +89,6 @@ local function bikelanes(object_tags, object_geom)
           _infrastructureExists = true,
           prefix = transformed_tags._prefix,
           lifecycle = transformed_tags.lifecycle or SANITIZE_ROAD_TAGS.temporary(transformed_tags) or object_tags.lifecycle,
-          width = parse_length(transformed_tags.width),
-          width_source = transformed_tags['source:width'],
           width_effective = parse_length(transformed_tags['width:effective']),
           oneway = derive_oneway(transformed_tags, category),
           bridge = SANITIZE_TAGS.boolean_yes(object_tags.bridge),
@@ -131,6 +130,7 @@ local function bikelanes(object_tags, object_geom)
 
         merge_table(result_tags, derive_traffic_mode(transformed_tags, object_tags, category.id, transformed_tags._side))
         merge_table(result_tags, derive_traffic_signs(transformed_tags))
+        merge_table(result_tags, derive_width(transformed_tags))
         merge_table(result_tags, derive_bikelane_surface(transformed_tags, category))
         merge_table(result_tags, derive_bikelane_smoothness(transformed_tags, category))
         result_tags.description = SANITIZE_TAGS.safe_string(result_tags.description)

--- a/processing/topics/roads_bikelanes/roads/road_classification.lua
+++ b/processing/topics/roads_bikelanes/roads/road_classification.lua
@@ -1,4 +1,5 @@
 local derive_traffic_signs = require('topics.helper.derive_traffic_signs')
+local derive_width = require('topics.helper.derive_width')
 local SANITIZE_TAGS = require('topics.helper.sanitize_tags')
 local parse_length = require('topics.helper.parse_length')
 local merge_table = require('topics.helper.merge_table')
@@ -11,14 +12,13 @@ local function road_classification(object_tags)
     road = road_classification_road_value(object_tags),
     oneway = SANITIZE_TAGS.oneway_road(object_tags),
     oneway_bicycle = SANITIZE_TAGS.oneway_bicycle(object_tags['oneway:bicycle']),
-    width = parse_length(object_tags.width),
-    width_source = SANITIZE_TAGS.safe_string(object_tags['source:width']),
     width_effective = parse_length(object_tags['width:effective']),
     bridge = SANITIZE_TAGS.boolean_yes(object_tags.bridge),
     tunnel = SANITIZE_TAGS.boolean_yes(object_tags.tunnel),
   }
 
   merge_table(result_tags, derive_traffic_signs(object_tags))
+  merge_table(result_tags, derive_width(object_tags))
 
   return result_tags
 end

--- a/topic-docs/roads_bikelanes/bikelanes.yaml
+++ b/topic-docs/roads_bikelanes/bikelanes.yaml
@@ -128,6 +128,8 @@ attributes:
     ref: roads.width_effective
   - key: width_source
     ref: roads.width_source
+  - key: width_confidence
+    ref: roads.width_confidence
   - key: oneway
     label: Verkehrsrichtung
     values:

--- a/topic-docs/roads_bikelanes/roads.yaml
+++ b/topic-docs/roads_bikelanes/roads.yaml
@@ -149,6 +149,16 @@ attributes:
         label: Aus ALKIS Daten ausgemessen
       - value: ARCore
         label: Mit dem Handy-Metermaß von StreetComplete gemessen
+  - key: width_confidence
+    purpose: qa
+    label: Konfidenz Breite
+    values:
+      - value: high
+        label: Direkt gemessen
+        description: Wert stammt aus dem OSM-Tag `width`.
+      - value: low
+        label: Geschätzt
+        description: Wert stammt aus dem OSM-Tag `est_width`, weil `width` fehlt oder nicht geparst werden konnte.
   - key: oneway
     label: Verkehrsrichtung
     values:

--- a/topic-docs/roads_bikelanes/roadsPathClasses.yaml
+++ b/topic-docs/roads_bikelanes/roadsPathClasses.yaml
@@ -40,6 +40,8 @@ attributes:
     ref: roads.width
   - key: width_source
     ref: roads.width_source
+  - key: width_confidence
+    ref: roads.width_confidence
   - key: surface
     ref: roads.surface
   - key: surface_source


### PR DESCRIPTION
## Summary
- Rebuild of [#289](https://github.com/FixMyBerlin/tilda-geo/pull/289) against current `develop`, following TILDA `derive_*` patterns (`derive_surface`) instead of the earlier vibe-coded approach.
- Roads and bikelanes now fall back from OSM `width` → `est_width`, with `width_confidence` (`high` / `low`) and existing free-text `width_source` (`source:width`) stored in **tags** (no extra DB columns, no export hacks).
- Inspector picks this up automatically via `TagsTableRowValueSourceConfidence`; topic-docs document the new confidence values.
- Addresses [private-issues#280](https://github.com/FixMyBerlin/private-issues/issues/280).

## What changed vs #289
- Dropped: `parse_width`, `width_errors`, dedicated DB columns, export API special-cases, custom `TagsTableRowCompositWidth`, unrelated knip/package churn.
- Kept/clarified intent: `parse_length` reuse, `derive_width` with local helpers, metadata in tags, bikelanes wired too (YAML claimed it; processing now sets it).

## Test plan
- [x] `processing/`: `bun run test` (570 Lua tests)
- [x] `app/`: `bun run check`
- [ ] Spot-check inspector on a road with `width` + `source:width` → “Direkt gemessen”
- [ ] Spot-check a way with only `est_width` → “Geschätzt”
- [ ] Confirm exports still include width fields via tags jsonb (no schema change)

Supersedes #289.

Made with [Cursor](https://cursor.com)